### PR TITLE
Add answer-style open problem interface

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@ List the Lean modules, blueprint nodes, or documentation files affected.
 
 - [ ] `lake build`
 - [ ] `lake build EconCSLib.Examples`
-- [ ] `rg -n '\b(sorry|admit)\b' EconCSLib -g '*.lean'` returned no matches
+- [ ] `python3 scripts/check_lean_placeholders.py EconCSLib` passed
 - [ ] `git diff --check`
 - [ ] Blueprint checks run when `docs/knowledge/` changed
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,11 +46,7 @@ jobs:
         run: lake build EconCSLib.Examples
 
       - name: Check Lean sources for placeholders
-        run: |
-          if rg -n '\b(sorry|admit)\b' EconCSLib -g '*.lean'; then
-            echo "Lean source modules must not contain sorry or admit."
-            exit 1
-          fi
+        run: python3 scripts/check_lean_placeholders.py EconCSLib
 
       - name: Check diff whitespace
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,9 @@ improve readability.
 
 ## Placeholder Policy
 
-Lean source under `EconCSLib/` must not contain `sorry` or `admit`.
+Lean source under `EconCSLib/` must not contain ordinary `sorry` or `admit`.
+Open-problem theorems under `EconCSLib/OpenProblem/` may use only the scoped
+`answer(sorry) ↔ P := by sorry` pattern.
 
 When a mathematical target is not ready for implementation:
 
@@ -148,10 +150,10 @@ Run checks from the repository root and scale them to the files changed.
 ```bash
 lake build
 lake build EconCSLib.Examples
-rg -n '\b(sorry|admit)\b' EconCSLib -g '*.lean'
+python3 scripts/check_lean_placeholders.py EconCSLib
 ```
 
-The final `rg` command must return no matches.
+The placeholder checker must pass.
 
 ### Knowledge-base changes
 
@@ -185,7 +187,7 @@ git diff --check
 ## CI Workflows
 
 - `.github/workflows/build.yml`: builds the stable library and examples,
-  rejects Lean placeholders, and checks diff whitespace.
+  rejects disallowed Lean placeholders, and checks diff whitespace.
 - `.github/workflows/blueprint.yml`: validates the blueprint on pull requests
   and deploys the generated site only from `main`.
 - `.github/workflows/docs.yml`: builds and deploys API reference output from

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,8 @@ blueprint nodes are all useful.
 Keep changes focused and follow nearby Lean style. Add public stable modules to
 `EconCSLib.lean`; keep examples and experimental open-problem interfaces opt-in.
 Do not add textbook PDFs, scans, OCR output, generated documentation sites, or
-Lean placeholders.
+ordinary Lean placeholders. Open-problem theorems may use the scoped
+`answer(sorry) ↔ P := by sorry` pattern under `EconCSLib/OpenProblem/`.
 
 Run the relevant checks before opening a pull request:
 
@@ -27,7 +28,7 @@ Run the relevant checks before opening a pull request:
 lake exe cache get
 lake build
 lake build EconCSLib.Examples
-rg -n '\b(sorry|admit)\b' EconCSLib -g '*.lean'
+python3 scripts/check_lean_placeholders.py EconCSLib
 git diff --check
 ```
 
@@ -39,7 +40,7 @@ python3 scripts/check_knowledge_references.py docs/knowledge
 mdblueprint-check docs/knowledge --lean-root .
 ```
 
-The placeholder search must return no matches.
+The placeholder checker must pass.
 
 ## Pull Requests
 

--- a/EconCSLib/OpenProblem.lean
+++ b/EconCSLib/OpenProblem.lean
@@ -1,0 +1,17 @@
+/-
+Copyright (c) 2026 EconCSLib contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+
+import EconCSLib.OpenProblem.EFXExistence
+import EconCSLib.OpenProblem.SubmodularWelfareDemandOracle
+import EconCSLib.OpenProblem.Util.Answer
+import EconCSLib.OpenProblem.Util.AnswerSyntax
+
+/-!
+# EconCSLib.OpenProblem
+
+Opt-in aggregate import for experimental open-problem interfaces.
+
+This module is intentionally not imported by `EconCSLib.lean`.
+-/

--- a/EconCSLib/OpenProblem.lean
+++ b/EconCSLib/OpenProblem.lean
@@ -5,8 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 
 import EconCSLib.OpenProblem.EFXExistence
 import EconCSLib.OpenProblem.SubmodularWelfareDemandOracle
-import EconCSLib.OpenProblem.Util.Answer
-import EconCSLib.OpenProblem.Util.AnswerSyntax
 
 /-!
 # EconCSLib.OpenProblem

--- a/EconCSLib/OpenProblem/EFXExistence.lean
+++ b/EconCSLib/OpenProblem/EFXExistence.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2026 EconCSLib contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+
+import EconCSLib.OpenProblem.Util.Answer
+import EconCSLib.SocialChoice.FairDivision.Indivisible.Instance
+
+/-!
+# EconCSLib.OpenProblem.EFXExistence
+
+This file records the major open problem of whether complete EFX allocations
+exist for indivisible goods with additive nonnegative valuations.
+
+The nontrivial unresolved range is four or more agents. EconCSLib already proves
+the two-agent additive case in
+`SocialChoice.FairDivision.Indivisible.efx_exists_two_agents`; the three-agent
+case is known in the literature but is not formalized here.
+
+## References
+
+* Plaut and Roughgarden, "Almost Envy-Freeness with General Valuations" (SODA
+  2018).
+* Chaudhury, Garg, and Mehlhorn, "EFX Allocations for Three Agents" (EC 2020).
+-/
+
+open Finset
+
+namespace SocialChoice
+namespace FairDivision
+namespace Indivisible
+
+/-- Open-problem statement: every additive nonnegative indivisible-goods
+instance with at least four agents has a complete EFX allocation. -/
+def EFXExistenceStatement : Prop :=
+  ∀ (N G : Type*) [Fintype N] [Fintype G] [DecidableEq G],
+    4 ≤ Fintype.card N →
+      ∀ I : AdditiveInstance N G,
+        (∀ i g, 0 ≤ I.weight i g) →
+          ∃ A : Allocation N G, I.feasible A ∧ I.IsEFX A
+
+/-- English version: "For every finite additive nonnegative indivisible-goods
+instance with at least four agents, does there exist a complete EFX allocation?"
+
+The `answer(sorry)` marker records that the mathematical answer is unresolved;
+it is not a proof of either side of the question. -/
+theorem efxExistence : answer(sorry) ↔ EFXExistenceStatement := by
+  sorry
+
+end Indivisible
+end FairDivision
+end SocialChoice

--- a/EconCSLib/OpenProblem/EFXExistence.lean
+++ b/EconCSLib/OpenProblem/EFXExistence.lean
@@ -24,8 +24,6 @@ case is known in the literature but is not formalized here.
 * Chaudhury, Garg, and Mehlhorn, "EFX Allocations for Three Agents" (EC 2020).
 -/
 
-open Finset
-
 namespace SocialChoice
 namespace FairDivision
 namespace Indivisible

--- a/EconCSLib/OpenProblem/SubmodularWelfareDemandOracle.lean
+++ b/EconCSLib/OpenProblem/SubmodularWelfareDemandOracle.lean
@@ -5,21 +5,22 @@ Released under Apache 2.0 license as described in the file LICENSE.
 
 import EconCSLib.MechanismDesign.Auction.VCG
 import EconCSLib.Foundation.Utility.Lottery
+import EconCSLib.OpenProblem.Util.Answer
 import Mathlib.Analysis.SpecialFunctions.Exp
 
 open scoped BigOperators
 
 /-!
-# EconCSLib.OpenProblem.OpenProblem1
+# EconCSLib.OpenProblem.SubmodularWelfareDemandOracle
 
 This file formalizes the interface of one open problem in algorithmic mechanism
 design: randomized submodular welfare maximization with demand queries.
 
 The development is intentionally interface-level. It defines bundle valuations,
 value and demand oracles, disjoint bundle allocations, the induced social
-welfare and optimum, a randomized algorithm interface, and a final proposition
-stating the existence of a polynomial-time demand-oracle algorithm beating the
-`1 - 1/e` barrier.
+welfare and optimum, a randomized algorithm interface, and a final open-problem
+statement asking whether a polynomial-time demand-oracle algorithm can beat the
+`1 - 1/e` barrier by some fixed positive constant.
 
 ## References
 
@@ -244,14 +245,19 @@ noncomputable def expectedBundlePartitionSocialWelfare
 -/
 
 /-- Named predicate for polynomial running time in the number of agents and
-items. This is an interface-level placeholder until a concrete cost model is
-chosen. -/
+items.
+
+This is an interface-level hook until a concrete cost model is chosen; it should
+not be read as a completed formalization of polynomial-time computation. -/
 def PolynomialTimeInAgentsItems (_agents _items : ℕ) : Prop :=
   True
 
 /-- Named predicate for polynomially many bundle-oracle queries in the number
-of agents and items. This covers value and demand queries to `BundleOracle`
-packages in this file. -/
+of agents and items.
+
+This is an interface-level hook covering value and demand queries to
+`BundleOracle` packages in this file; it is not yet a completed query-complexity
+model. -/
 def PolynomialBundleOracleQueryBound (_agents _items : ℕ) : Prop :=
   True
 
@@ -266,15 +272,30 @@ def RandomizedSubmodularWelfareAlgorithm.IsPolynomial
   PolynomialTimeInAgentsItems (n I) M.card ∧
     PolynomialBundleOracleQueryBound (n I) M.card
 
-/-- Open problem: there exists a randomized demand-oracle SWM algorithm beating
-the `1 - 1/e` barrier by `0.01` for the fixed agent, item, and seed domains. -/
-noncomputable def ExistsDemandOracleSWMAlgorithmBeatingOneMinusInvE
+/-- Open-problem statement: for the fixed agent, item, and seed domains, there
+is a randomized demand-oracle SWM algorithm beating the `1 - 1/e` barrier by
+some fixed positive constant. -/
+noncomputable def DemandOracleSWMBeatsOneMinusInvEStatement
     (I Ω : Type*) {G : Type*} [Fintype I] [Fintype Ω] [DecidableEq G]
     (M : Finset G) [Fintype (BundlePartitionAllocation I M)]
     [Nonempty (BundlePartitionAllocation I M)] : Prop :=
-  ∃ alg : RandomizedSubmodularWelfareAlgorithm I Ω M,
-    alg.IsPolynomial ∧
-      ∀ profile : SubmodularWelfareMaximizationProfile I M,
-        (1 - 1 / Real.exp 1 + (1 / 100 : ℝ)) *
-            OPT (fun i => (profile.oracle i).valuation) ≤
-          expectedBundlePartitionSocialWelfare alg profile
+  ∃ ε : ℝ, 0 < ε ∧
+    ∃ alg : RandomizedSubmodularWelfareAlgorithm I Ω M,
+      alg.IsPolynomial ∧
+        ∀ profile : SubmodularWelfareMaximizationProfile I M,
+          (1 - 1 / Real.exp 1 + ε) *
+              OPT (fun i => (profile.oracle i).valuation) ≤
+            expectedBundlePartitionSocialWelfare alg profile
+
+/-- English version: "Is there a randomized demand-oracle algorithm for
+submodular welfare maximization that beats the `1 - 1/e` approximation barrier
+by a fixed positive constant?"
+
+The `answer(sorry)` marker records that the mathematical answer is unresolved;
+it is not a proof of either side of the question. -/
+theorem demandOracleSWMBeatsOneMinusInvE
+    (I Ω : Type*) {G : Type*} [Fintype I] [Fintype Ω] [DecidableEq G]
+    (M : Finset G) [Fintype (BundlePartitionAllocation I M)]
+    [Nonempty (BundlePartitionAllocation I M)] :
+    answer(sorry) ↔ DemandOracleSWMBeatsOneMinusInvEStatement I Ω M := by
+  sorry

--- a/EconCSLib/OpenProblem/Util/Answer.lean
+++ b/EconCSLib/OpenProblem/Util/Answer.lean
@@ -1,0 +1,165 @@
+/-
+Copyright 2025 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public meta import Lean.Elab.SyntheticMVars
+public import EconCSLib.OpenProblem.Util.AnswerSyntax
+
+import Batteries.Lean.Expr
+
+/-!
+# The `answer()` elaborator for EconCSLib open problems
+
+This file provides syntax for marking answers in open-problem statements.
+
+It is adapted from `FormalConjectures.Util.Answer` in
+`google-deepmind/formal-conjectures`. EconCSLib keeps the mechanism opt-in under
+`EconCSLib.OpenProblem` and uses the option `econcslib.answer`.
+
+`answer(sorry)` is a marker for an unresolved mathematical answer. Replacing it
+with a term is not the same as proving the problem: whether the supplied answer
+is mathematically meaningful remains a human judgment.
+-/
+
+public meta section
+
+namespace EconCSLib.OpenProblem
+
+open Lean Elab Meta Term
+
+/-- A type that captures the current setting for the `answer()` elaborator. -/
+inductive AnswerSetting
+  /-- Default mode: `answer(sorry)` defaults to `True` when `sorry` has type `Prop`. -/
+  | alwaysTrue
+  /-- Default mode for `answer(foo)`: postpone elaboration. -/
+  | postpone
+  /-- Elaborate `answer(foo)` by creating an auxiliary definition with value `foo`. -/
+  | withAuxiliary
+deriving Inhabited, ToJson, BEq
+
+instance : ToString AnswerSetting where
+  toString
+    | .postpone => "postpone"
+    | .withAuxiliary => "with_auxiliary"
+    | .alwaysTrue => "always_true"
+
+instance : KVMap.Value AnswerSetting where
+  toDataValue := DataValue.ofString ∘ ToString.toString
+  ofDataValue?
+    | .ofString "postpone" => some .postpone
+    | .ofString "with_auxiliary" => some .withAuxiliary
+    | .ofString "always_true" => some .alwaysTrue
+    | _ => none
+
+register_option econcslib.answer : AnswerSetting := {
+  defValue := .alwaysTrue
+  descr := "Modifies the behaviour of the EconCSLib open-problem answer() elaborator."
+}
+
+def mkAnswerAnnotation (e : Expr) : Expr := mkAnnotation `answer e
+
+/-- Find the first subexpression carrying the `answer` annotation,
+returning the inner expression if found. -/
+def findAnswerExpr (e : Expr) : Option Expr :=
+  (e.find? fun
+    | .mdata m _ => m.contains `answer
+    | _ => false).map Expr.mdataExpr!
+
+/-- Collect all subexpressions carrying the `answer` annotation,
+returning the inner expressions. -/
+partial def findAnswerExprs (e : Expr) : Array Expr :=
+  go e #[]
+where
+  go (e : Expr) (acc : Array Expr) : Array Expr :=
+    match e with
+    | .mdata m inner =>
+      go inner (if m.contains `answer then acc.push inner else acc)
+    | .app f a => go a (go f acc)
+    | .lam _ t b _ => go b (go t acc)
+    | .forallE _ t b _ => go b (go t acc)
+    | .letE _ t v b _ => go b (go v (go t acc))
+    | _ => acc
+
+def elabTermAndAnnotate (stx : TSyntax `term) (expectedType? : Option Expr)
+    (postpone : Bool := false) :=
+  mkAnswerAnnotation <$> do
+    if postpone then
+      postponeElabTerm (← `(by exact $stx)) expectedType?
+    else
+      elabTerm stx expectedType?
+
+/-- Indicates where the answer is in an open-problem statement. -/
+@[term_elab answer]
+def answerElab : TermElab := fun stx expectedType? => do
+  match stx with
+  | `(answer($a:term)) =>
+    match econcslib.answer.get (← getOptions) with
+    | AnswerSetting.postpone => elabTermAndAnnotate a expectedType? true
+    | .withAuxiliary =>
+      let expr ← elabTermAndSynthesize a expectedType?
+      let exprType ← (Meta.inferType expr) >>= instantiateMVars
+      if exprType.hasExprMVar then throwPostpone
+      let some declName := (← read).declName?
+        | throwError "Failed to find the name of the declaration"
+      let answerName : Name := declName.str "_answer"
+      let levelParamNames : List Name := (collectLevelParams {} exprType).params.toList
+      let answerAuxiliaryDecl : DefinitionVal := {
+        name := answerName
+        levelParams := levelParamNames
+        type := exprType
+        value := expr
+        hints := .abbrev
+        safety := .safe
+      }
+      addDecl (.defnDecl answerAuxiliaryDecl) true
+      return mkAnswerAnnotation (.const answerName <| levelParamNames.map Level.param)
+    | .alwaysTrue =>
+      if expectedType? == some (Expr.sort .zero) && a == (← `(term| sorry)) then
+        return .const `True []
+      else
+        elabTermAndAnnotate a expectedType? true
+  | _ => Elab.throwUnsupportedSyntax
+
+open InfoTree
+
+/-- An answer term and the context in which it was elaborated. -/
+structure AnswerInfo where
+  ctx : Elab.ContextInfo
+  term : Elab.TermInfo
+
+/-- Print an answer. -/
+def AnswerInfo.format (a : AnswerInfo) : Elab.Term.TermElabM MessageData :=
+  Meta.withMCtx a.ctx.mctx <| Meta.withLCtx a.term.lctx {} do
+    let t ← Meta.inferType a.term.expr
+    let m ← Meta.mkFreshExprMVar t
+    addMessageContextFull m!"{a.term.expr} in context:{indentD m.mvarId!}"
+
+/-- Find answers by inspecting an `InfoTree`. -/
+partial def getAnswers {m} [Monad m] (i : InfoTree) : m (Array AnswerInfo) :=
+  go none i
+where
+  go : _ → InfoTree → _
+  | ctx?, context ctx t => go (ctx.mergeIntoOuter? ctx?) t
+  | some ctx, node i cs => do
+    let ctx := i.updateContext? ctx
+    if let .ofTermInfo t := i then
+      if t.elaborator == ``answerElab then
+        if let some ctx := ctx then
+          return #[⟨ctx, t⟩]
+    return (← cs.mapM (go <| i.updateContext? ctx)).toArray.flatten
+  | _, _ => pure #[]
+
+end EconCSLib.OpenProblem

--- a/EconCSLib/OpenProblem/Util/Answer.lean
+++ b/EconCSLib/OpenProblem/Util/Answer.lean
@@ -91,6 +91,7 @@ where
     | .lam _ t b _ => go b (go t acc)
     | .forallE _ t b _ => go b (go t acc)
     | .letE _ t v b _ => go b (go v (go t acc))
+    | .proj _ _ e => go e acc
     | _ => acc
 
 def elabTermAndAnnotate (stx : TSyntax `term) (expectedType? : Option Expr)
@@ -101,7 +102,7 @@ def elabTermAndAnnotate (stx : TSyntax `term) (expectedType? : Option Expr)
     else
       elabTerm stx expectedType?
 
-/-- Indicates where the answer is in an open-problem statement. -/
+/-- Term elaborator for the `answer()` syntax in open-problem statements. -/
 @[term_elab answer]
 def answerElab : TermElab := fun stx expectedType? => do
   match stx with

--- a/EconCSLib/OpenProblem/Util/AnswerSyntax.lean
+++ b/EconCSLib/OpenProblem/Util/AnswerSyntax.lean
@@ -1,0 +1,28 @@
+/-
+Copyright 2025 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+/-!
+Syntax definitions for the EconCSLib open-problem `answer()` elaborator.
+
+Adapted from `FormalConjectures.Util.Answer.Syntax` in
+`google-deepmind/formal-conjectures`.
+-/
+
+public section
+
+/-- Indicates where the answer is in an open-problem statement. -/
+syntax (name := EconCSLib.OpenProblem.answer) "answer(" term ")" : term

--- a/docs/design.md
+++ b/docs/design.md
@@ -52,11 +52,18 @@ Foundation/   Math/
   import is clear.
 - Add intended stable modules to `EconCSLib.lean`.
 
-### Keep the Lean tree placeholder-free
+### Keep the stable Lean tree placeholder-free
 
-Public Lean source under `EconCSLib/` must not contain `sorry` or `admit`.
+Public Lean source under `EconCSLib/` must not contain ordinary `sorry` or
+`admit`.
 Mathematical targets that are not yet implemented belong in the knowledge
 blueprint or issue tracker, not as deferred Lean declarations.
+
+Experimental open-problem interfaces under `EconCSLib/OpenProblem/` have one
+scoped exception: theorem statements may use `answer(sorry) ↔ P := by sorry` to
+record an unresolved yes/no answer in the style of Formal Conjectures. This
+exception is checked by `scripts/check_lean_placeholders.py`; ordinary `sorry`
+and all `admit` uses remain forbidden.
 
 ## Source Layout
 

--- a/docs/maintainers/initial-public-release.md
+++ b/docs/maintainers/initial-public-release.md
@@ -114,14 +114,14 @@ Confirm that deletions match the intended cleanup:
 ```bash
 git diff --name-only --diff-filter=D
 git ls-files | rg '\.(pdf|zip|jsonl|pyc)$|(^|/)__pycache__/|^references/' || true
-rg -n '\b(sorry|admit)\b' EconCSLib -g '*.lean' || true
+python3 scripts/check_lean_placeholders.py EconCSLib
 rg -n 'docs/dev|PLAN\.md|\.sorry-crusher|maschler_statements' \
   README.md AGENTS.md CONTRIBUTING.md docs scripts .github EconCSLib \
   -g '!initial-public-release.md' || true
 ```
 
-The last three commands must return no tracked artifacts, source placeholders,
-or stale private-development paths.
+The artifact and private-path searches must return no matches, and the
+placeholder checker must pass.
 
 Run the local checks:
 
@@ -129,15 +129,15 @@ Run the local checks:
 lake exe cache get
 lake build
 lake build EconCSLib.Examples
-rg -n '\b(sorry|admit)\b' EconCSLib/Examples -g '*.lean'
+python3 scripts/check_lean_placeholders.py EconCSLib
 python3 -m unittest tests/test_check_knowledge_references.py
 python3 scripts/check_knowledge_references.py docs/knowledge
 mdblueprint-check docs/knowledge --lean-root .
 git diff --check
 ```
 
-The example placeholder search must return no matches. `mdblueprint-check`
-should finish with `0 error(s), 0 warning(s)`.
+The placeholder checker must pass. `mdblueprint-check` should finish with
+`0 error(s), 0 warning(s)`.
 
 Build both generated documentation products once:
 
@@ -449,14 +449,15 @@ Confirm that private and generated artifacts did not enter the snapshot:
 
 ```bash
 git ls-files | rg '\.(pdf|zip|jsonl|pyc)$|(^|/)__pycache__/|^references/' || true
-rg -n '\b(sorry|admit)\b' EconCSLib -g '*.lean' || true
+python3 scripts/check_lean_placeholders.py EconCSLib
 rg -n 'docs/dev|PLAN\.md|\.sorry-crusher|maschler_statements' \
   README.md AGENTS.md CONTRIBUTING.md docs scripts .github EconCSLib \
   -g '!initial-public-release.md' || true
 git status --short
 ```
 
-The repository should be clean, and the searches should return no matches.
+The repository should be clean, the artifact/private-path searches should
+return no matches, and the placeholder checker should pass.
 
 Run the release checks in the snapshot:
 
@@ -464,15 +465,15 @@ Run the release checks in the snapshot:
 lake exe cache get
 lake build
 lake build EconCSLib.Examples
-rg -n '\b(sorry|admit)\b' EconCSLib/Examples -g '*.lean'
+python3 scripts/check_lean_placeholders.py EconCSLib
 python3 -m unittest tests/test_check_knowledge_references.py
 python3 scripts/check_knowledge_references.py docs/knowledge
 mdblueprint-check docs/knowledge --lean-root .
 git diff --check
 ```
 
-The example placeholder search must return no matches. The build may emit the
-known Lean deprecation and linter warnings.
+The placeholder checker must pass. The build may emit the known Lean
+deprecation and linter warnings.
 
 ## Phase 7: Push and Observe the First Public CI Run
 
@@ -616,14 +617,14 @@ cd "$VERIFY_DIR"
 lake exe cache get
 lake build
 lake build EconCSLib.Examples
-rg -n '\b(sorry|admit)\b' EconCSLib -g '*.lean'
+python3 scripts/check_lean_placeholders.py EconCSLib
 python3 -m unittest tests/test_check_knowledge_references.py
 python3 scripts/check_knowledge_references.py docs/knowledge
 mdblueprint-check docs/knowledge --lean-root .
 git diff --check
 ```
 
-The placeholder search must return no matches.
+The placeholder checker must pass.
 
 ## Phase 10: Tag and Publish `v0.1.0`
 

--- a/docs/maintainers/knowledge-blueprint.md
+++ b/docs/maintainers/knowledge-blueprint.md
@@ -44,14 +44,14 @@ root:
 ```bash
 lake build
 lake build EconCSLib.Examples
-rg -n '\b(sorry|admit)\b' EconCSLib -g '*.lean'
+python3 scripts/check_lean_placeholders.py EconCSLib
 python3 -m unittest tests/test_check_knowledge_references.py
 python3 scripts/check_knowledge_references.py docs/knowledge
 mdblueprint-check docs/knowledge --lean-root .
 git diff --check
 ```
 
-The placeholder search must return no matches.
+The placeholder checker must pass.
 
 To build a preview:
 

--- a/scripts/check_lean_placeholders.py
+++ b/scripts/check_lean_placeholders.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Check Lean source files for disallowed placeholders.
+
+Ordinary `sorry` and `admit` are forbidden in EconCSLib Lean source. Open
+problem modules may use the upstream-style pattern
+
+    theorem problemName : answer(sorry) ↔ P := by
+      sorry
+
+under `EconCSLib/OpenProblem/`. The answer elaborator implementation itself has
+one syntax quotation mentioning `sorry`; this script allows that exact use.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+
+TOKEN_RE = re.compile(r"\b(sorry|admit)\b")
+
+
+def strip_comments_and_strings(text: str) -> str:
+    """Return text with Lean comments and strings replaced by spaces."""
+
+    out: list[str] = []
+    i = 0
+    block_depth = 0
+    in_line_comment = False
+    in_string = False
+    in_char = False
+
+    while i < len(text):
+        c = text[i]
+        n = text[i + 1] if i + 1 < len(text) else ""
+
+        if in_line_comment:
+            if c == "\n":
+                in_line_comment = False
+                out.append(c)
+            else:
+                out.append(" ")
+            i += 1
+            continue
+
+        if block_depth:
+            if c == "/" and n == "-":
+                block_depth += 1
+                out.extend("  ")
+                i += 2
+            elif c == "-" and n == "/":
+                block_depth -= 1
+                out.extend("  ")
+                i += 2
+            else:
+                out.append("\n" if c == "\n" else " ")
+                i += 1
+            continue
+
+        if in_string:
+            if c == "\\" and n:
+                out.extend("  ")
+                i += 2
+            elif c == '"':
+                in_string = False
+                out.append(" ")
+                i += 1
+            else:
+                out.append("\n" if c == "\n" else " ")
+                i += 1
+            continue
+
+        if in_char:
+            if c == "\\" and n:
+                out.extend("  ")
+                i += 2
+            elif c == "'":
+                in_char = False
+                out.append(" ")
+                i += 1
+            else:
+                out.append("\n" if c == "\n" else " ")
+                i += 1
+            continue
+
+        if c == "-" and n == "-":
+            in_line_comment = True
+            out.extend("  ")
+            i += 2
+        elif c == "/" and n == "-":
+            block_depth = 1
+            out.extend("  ")
+            i += 2
+        elif c == '"':
+            in_string = True
+            out.append(" ")
+            i += 1
+        elif c == "'":
+            in_char = True
+            out.append(" ")
+            i += 1
+        else:
+            out.append(c)
+            i += 1
+
+    return "".join(out)
+
+
+def line_col(text: str, pos: int) -> tuple[int, int]:
+    line = text.count("\n", 0, pos) + 1
+    line_start = text.rfind("\n", 0, pos) + 1
+    return line, pos - line_start + 1
+
+
+def is_under_open_problem(path: pathlib.Path) -> bool:
+    parts = path.parts
+    return "EconCSLib" in parts and "OpenProblem" in parts
+
+
+def is_answer_sorry(code: str, pos: int) -> bool:
+    return code[:pos].rstrip().endswith("answer(")
+
+
+def is_answer_utility_quote(path: pathlib.Path, code: str, pos: int) -> bool:
+    return (
+        path.as_posix().endswith("EconCSLib/OpenProblem/Util/Answer.lean")
+        and code[:pos].rstrip().endswith("`(term|")
+    )
+
+
+def is_open_problem_proof_sorry(code: str, pos: int) -> bool:
+    prefix = code[:pos].rstrip()
+    if not prefix.endswith(":= by"):
+        return False
+
+    theorem_pos = max(prefix.rfind("\ntheorem "), prefix.rfind("\nlemma "))
+    if prefix.startswith("theorem ") or prefix.startswith("lemma "):
+        theorem_pos = 0
+    if theorem_pos < 0:
+        return False
+
+    decl_prefix = prefix[theorem_pos:]
+    return re.search(r"\banswer\s*\(\s*sorry\s*\)\s*↔", decl_prefix) is not None
+
+
+def check_file(path: pathlib.Path, root: pathlib.Path) -> list[str]:
+    text = path.read_text(encoding="utf-8")
+    code = strip_comments_and_strings(text)
+    errors: list[str] = []
+
+    for match in TOKEN_RE.finditer(code):
+        token = match.group(1)
+        pos = match.start()
+        rel = path.relative_to(root)
+        loc = line_col(text, pos)
+
+        if token == "admit":
+            errors.append(f"{rel}:{loc[0]}:{loc[1]}: disallowed admit")
+            continue
+
+        if not is_under_open_problem(path):
+            errors.append(f"{rel}:{loc[0]}:{loc[1]}: disallowed sorry outside OpenProblem")
+            continue
+
+        if (
+            is_answer_sorry(code, pos)
+            or is_answer_utility_quote(path, code, pos)
+            or is_open_problem_proof_sorry(code, pos)
+        ):
+            continue
+
+        errors.append(
+            f"{rel}:{loc[0]}:{loc[1]}: disallowed sorry; use only "
+            "`answer(sorry)` statements and their direct `by sorry` proofs"
+        )
+
+    return errors
+
+
+def iter_lean_files(paths: list[pathlib.Path]) -> list[pathlib.Path]:
+    files: list[pathlib.Path] = []
+    for path in paths:
+        if path.is_file() and path.suffix == ".lean":
+            files.append(path)
+        elif path.is_dir():
+            files.extend(sorted(path.rglob("*.lean")))
+    return files
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("paths", nargs="*", default=["EconCSLib"])
+    args = parser.parse_args()
+
+    root = pathlib.Path.cwd()
+    files = iter_lean_files([pathlib.Path(p) for p in args.paths])
+    errors: list[str] = []
+    for path in files:
+        errors.extend(check_file(path.resolve(), root.resolve()))
+
+    if errors:
+        print("\n".join(errors))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add an EconCSLib-scoped answer() elaborator for open-problem statements
- convert the existing submodular welfare open problem to the answer(sorry) style and rename its module descriptively
- add an EFX existence open problem for additive nonnegative indivisible-goods instances with at least four agents
- replace raw placeholder grep checks with a scoped Lean placeholder checker

## Checks
- lake exe cache get
- lake build EconCSLib.OpenProblem
- lake build
- lake build EconCSLib.Examples
- python3 scripts/check_lean_placeholders.py EconCSLib
- git diff --check