### PR TITLE
Integrate extensive game subgame restrictions

### DIFF
--- a/EconCSLib/Examples.lean
+++ b/EconCSLib/Examples.lean
@@ -12,6 +12,7 @@ import EconCSLib.Examples.RockPaperScissors
 import EconCSLib.Examples.SimpleAuction
 import EconCSLib.Examples.SimpleGameTree
 import EconCSLib.Examples.TicTacToe
+import EconCSLib.Examples.UltimatumGame
 
 /-!
 # EconCSLib.Examples

--- a/EconCSLib/Examples/CentipedeGame.lean
+++ b/EconCSLib/Examples/CentipedeGame.lean
@@ -6,10 +6,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import EconCSLib.GameTheory.ExtensiveGame.Basic
 import EconCSLib.GameTheory.ExtensiveGame.FiniteArenaExtraction
 import EconCSLib.GameTheory.ExtensiveGame.GameTreeNE
+import Mathlib.Data.Fintype.Basic
 import Mathlib.Data.Rat.Cast.Defs
 
 /-!
-# EconCSLib.Examples.CentipedeGame
+# Examples.CentipedeGame
 
 The Centipede Game with the Arena framework.
 
@@ -176,16 +177,30 @@ def centipedePrefixArena : ExtensiveGame (Fin 2) ℤ where
   mover := PrefixState.mover
   payoff := PrefixState.payoff
 
+/-- The terminal payoff when Player I stops immediately. -/
+def centipedePrefixStop0Leaf : GameTree (Fin 2) ℤ :=
+  GameTree.Leaf (fun i => if i = 0 then 1 else 0)
+
+/-- The terminal payoff when Player II stops after Player I continues. -/
+def centipedePrefixStop1Leaf : GameTree (Fin 2) ℤ :=
+  GameTree.Leaf (fun i => if i = 0 then 0 else 3)
+
+/-- The terminal payoff when both players continue in the two-decision prefix. -/
+def centipedePrefixContinue1Leaf : GameTree (Fin 2) ℤ :=
+  GameTree.Leaf (fun i => if i = 0 then 3 else 2)
+
+/-- Player II's subgame after Player I continues in the two-decision prefix. -/
+def centipedePrefixContinuationTree : GameTree (Fin 2) ℤ :=
+  GameTree.Node (1 : Fin 2)
+    centipedePrefixStop1Leaf
+    (List.cons centipedePrefixContinue1Leaf List.nil)
+
 /-- A small two-decision finite-tree centipede prefix using the same payoff
     convention as the Arena example. -/
 def centipedePrefixTree : GameTree (Fin 2) ℤ :=
   GameTree.Node (0 : Fin 2)
-    (GameTree.Leaf (fun i => if i = 0 then 1 else 0))
-    (List.cons
-      (GameTree.Node (1 : Fin 2)
-        (GameTree.Leaf (fun i => if i = 0 then 0 else 3))
-        (List.cons (GameTree.Leaf (fun i => if i = 0 then 3 else 2)) List.nil))
-      List.nil)
+    centipedePrefixStop0Leaf
+    (List.cons centipedePrefixContinuationTree List.nil)
 
 /-- The finite-tree centipede prefix has a root-scoped subgame-perfect
     equilibrium by backward induction. -/
@@ -202,6 +217,594 @@ theorem centipedePrefix_has_nash_at :
   obtain ⟨σ, hspe⟩ := centipedePrefix_has_spe_on
   exact ⟨σ, hspe.toNashAt⟩
 
+/-- The concrete backward-induction strategy in the two-decision centipede
+    prefix: stop at every decision node. -/
+def centipedePrefixStopStrategy : GameTree.Strategy (Fin 2) ℤ :=
+  fun _ h _ => ⟨h, by simp⟩
+
+/-- Stopping is Nash in Player II's continuation subgame: Player II receives
+    `3` from stopping and only `2` from continuing. -/
+theorem centipedePrefixStop_isNashAt_continuation :
+    GameTree.IsNashAt centipedePrefixStopStrategy
+      centipedePrefixContinuationTree := by
+  intro i σ' hiv
+  fin_cases i
+  · have hsame :
+        σ' (1 : Fin 2) centipedePrefixStop1Leaf
+            (List.cons centipedePrefixContinue1Leaf List.nil) =
+          centipedePrefixStopStrategy (1 : Fin 2) centipedePrefixStop1Leaf
+            (List.cons centipedePrefixContinue1Leaf List.nil) :=
+      (hiv (1 : Fin 2) centipedePrefixStop1Leaf
+        (List.cons centipedePrefixContinue1Leaf List.nil) (by decide)).symm
+    rw [centipedePrefixContinuationTree, GameTree.outcome_Node]
+    rw [hsame]
+    simp [centipedePrefixStopStrategy, centipedePrefixStop1Leaf]
+  · have hchoice_mem :
+        (σ' (1 : Fin 2) centipedePrefixStop1Leaf
+          (List.cons centipedePrefixContinue1Leaf List.nil)).val ∈
+            centipedePrefixStop1Leaf ::
+              List.cons centipedePrefixContinue1Leaf List.nil :=
+      (σ' (1 : Fin 2) centipedePrefixStop1Leaf
+        (List.cons centipedePrefixContinue1Leaf List.nil)).property
+    rcases List.mem_cons.mp hchoice_mem with hchoice | hchoice_tail
+    · rw [centipedePrefixContinuationTree, GameTree.outcome_Node]
+      rw [hchoice]
+      simp [centipedePrefixStopStrategy, centipedePrefixStop1Leaf]
+    · rcases List.mem_singleton.mp hchoice_tail with hchoice
+      rw [centipedePrefixContinuationTree, GameTree.outcome_Node]
+      rw [hchoice]
+      simp [centipedePrefixStopStrategy, centipedePrefixStop1Leaf,
+        centipedePrefixContinue1Leaf]
+
+/-- Stopping immediately is Nash at the root of the two-decision centipede
+    prefix, given that Player II stops in the continuation subgame. -/
+theorem centipedePrefixStop_isNashAt :
+    GameTree.IsNashAt centipedePrefixStopStrategy centipedePrefixTree := by
+  intro i σ' hiv
+  fin_cases i
+  · have hroot_mem :
+        (σ' (0 : Fin 2) centipedePrefixStop0Leaf
+          (List.cons centipedePrefixContinuationTree List.nil)).val ∈
+            centipedePrefixStop0Leaf ::
+              List.cons centipedePrefixContinuationTree List.nil :=
+      (σ' (0 : Fin 2) centipedePrefixStop0Leaf
+        (List.cons centipedePrefixContinuationTree List.nil)).property
+    rcases List.mem_cons.mp hroot_mem with hroot | hroot_tail
+    · rw [centipedePrefixTree, GameTree.outcome_Node]
+      rw [hroot]
+      simp [centipedePrefixStopStrategy, centipedePrefixStop0Leaf]
+    · have hsame :
+          σ' (1 : Fin 2) centipedePrefixStop1Leaf
+              (List.cons centipedePrefixContinue1Leaf List.nil) =
+            centipedePrefixStopStrategy (1 : Fin 2) centipedePrefixStop1Leaf
+              (List.cons centipedePrefixContinue1Leaf List.nil) :=
+        (hiv (1 : Fin 2) centipedePrefixStop1Leaf
+          (List.cons centipedePrefixContinue1Leaf List.nil) (by decide)).symm
+      rcases List.mem_singleton.mp hroot_tail with hroot
+      rw [centipedePrefixTree, GameTree.outcome_Node]
+      rw [hroot]
+      rw [centipedePrefixContinuationTree, GameTree.outcome_Node]
+      rw [hsame]
+      simp [centipedePrefixStopStrategy, centipedePrefixStop0Leaf,
+        centipedePrefixStop1Leaf]
+  · have hroot_same :
+        σ' (0 : Fin 2) centipedePrefixStop0Leaf
+            (List.cons centipedePrefixContinuationTree List.nil) =
+          centipedePrefixStopStrategy (0 : Fin 2) centipedePrefixStop0Leaf
+            (List.cons centipedePrefixContinuationTree List.nil) :=
+      (hiv (0 : Fin 2) centipedePrefixStop0Leaf
+        (List.cons centipedePrefixContinuationTree List.nil) (by decide)).symm
+    rw [centipedePrefixTree, GameTree.outcome_Node]
+    rw [hroot_same]
+    simp [centipedePrefixStopStrategy, centipedePrefixStop0Leaf]
+
+/-- Stopping at Player II's continuation node is subgame-perfect on that
+    continuation subgame. -/
+theorem centipedePrefixStop_isSubgamePerfectOn_continuation :
+    GameTree.IsSubgamePerfectOn centipedePrefixStopStrategy
+      centipedePrefixContinuationTree := by
+  change GameTree.IsSubgamePerfectOn centipedePrefixStopStrategy
+    (GameTree.Node (1 : Fin 2) centipedePrefixStop1Leaf
+      (List.cons centipedePrefixContinue1Leaf List.nil))
+  rw [GameTree.isSubgamePerfectOn_Node_iff]
+  refine ⟨centipedePrefixStop_isNashAt_continuation, ?_, ?_⟩
+  · exact GameTree.isSubgamePerfectOn_Leaf centipedePrefixStopStrategy
+      (fun i => if i = 0 then 0 else 3)
+  · intro c hc
+    rcases List.mem_singleton.mp hc with rfl
+    exact GameTree.isSubgamePerfectOn_Leaf centipedePrefixStopStrategy
+      (fun i => if i = 0 then 3 else 2)
+
+/-- The concrete backward-induction strategy is subgame-perfect at the root of
+    the two-decision centipede prefix. -/
+theorem centipedePrefixStop_isSubgamePerfectOn :
+    GameTree.IsSubgamePerfectOn centipedePrefixStopStrategy
+      centipedePrefixTree := by
+  change GameTree.IsSubgamePerfectOn centipedePrefixStopStrategy
+    (GameTree.Node (0 : Fin 2) centipedePrefixStop0Leaf
+      (List.cons centipedePrefixContinuationTree List.nil))
+  rw [GameTree.isSubgamePerfectOn_Node_iff]
+  refine ⟨centipedePrefixStop_isNashAt, ?_, ?_⟩
+  · exact GameTree.isSubgamePerfectOn_Leaf centipedePrefixStopStrategy
+      (fun i => if i = 0 then 1 else 0)
+  · intro c hc
+    rcases List.mem_singleton.mp hc with rfl
+    exact centipedePrefixStop_isSubgamePerfectOn_continuation
+
+/-- Select the first tail child when available; otherwise select the head.
+    On the binary prefix this means "continue". -/
+def centipedePrefixTailOrHead (h : GameTree (Fin 2) ℤ) :
+    (t : List (GameTree (Fin 2) ℤ)) → { c : GameTree (Fin 2) ℤ // c ∈ h :: t }
+  | [] => ⟨h, by simp⟩
+  | c :: _ => ⟨c, by simp⟩
+
+/-- The cooperative-looking strategy that continues at every decision node. -/
+def centipedePrefixContinueStrategy : GameTree.Strategy (Fin 2) ℤ :=
+  fun _ h t => centipedePrefixTailOrHead h t
+
+/-- A Player II deviation from all-continue: keep Player I's root continuation
+    choice, but stop in Player II's continuation subgame. -/
+def centipedePrefixContinueThenStopStrategy : GameTree.Strategy (Fin 2) ℤ :=
+  fun m h t =>
+    if m = (1 : Fin 2) then ⟨h, by simp⟩ else centipedePrefixTailOrHead h t
+
+/-- Continuing at both decision nodes reaches the high-payoff terminal branch
+    `(3, 2)` in the two-decision prefix. -/
+theorem centipedePrefixContinue_outcome :
+    GameTree.outcome centipedePrefixContinueStrategy centipedePrefixTree 0 = 3 ∧
+      GameTree.outcome centipedePrefixContinueStrategy centipedePrefixTree 1 = 2 := by
+  simp [centipedePrefixTree, centipedePrefixContinuationTree,
+    centipedePrefixContinueStrategy, centipedePrefixTailOrHead,
+    centipedePrefixContinue1Leaf]
+
+/-- The Player II stop-after-continuation deviation changes only Player II's
+    decision nodes relative to the all-continue strategy. -/
+theorem centipedePrefixContinueThenStop_playerOneVariant :
+    GameTree.IVariant (1 : Fin 2) centipedePrefixContinueStrategy
+      centipedePrefixContinueThenStopStrategy := by
+  intro m h t hm
+  simp [centipedePrefixContinueStrategy, centipedePrefixContinueThenStopStrategy,
+    centipedePrefixTailOrHead, hm]
+
+/-- The all-continue strategy is not Nash at the root: once Player I continues,
+    Player II prefers stopping for payoff `3` over continuing for payoff `2`. -/
+theorem centipedePrefixContinue_not_isNashAt :
+    ¬ GameTree.IsNashAt centipedePrefixContinueStrategy centipedePrefixTree := by
+  intro hnash
+  have hbad := hnash (1 : Fin 2) centipedePrefixContinueThenStopStrategy
+    centipedePrefixContinueThenStop_playerOneVariant
+  have hle : (3 : ℤ) ≤ 2 := by
+    simp [centipedePrefixTree, centipedePrefixContinuationTree,
+      centipedePrefixContinueStrategy, centipedePrefixContinueThenStopStrategy,
+      centipedePrefixTailOrHead, centipedePrefixStop1Leaf,
+      centipedePrefixContinue1Leaf] at hbad
+  exact (by decide : ¬ ((3 : ℤ) ≤ 2)) hle
+
+/-! ### MSZ Example 7.16: exact 100-stage Centipede tree -/
+
+/-- Payoff vector helper for the MSZ Centipede tree. -/
+def centipedeMSZPayoff (p0 p1 : ℤ) : Fin 2 → ℤ :=
+  fun i => if i = 0 then p0 else p1
+
+@[simp]
+theorem centipedeMSZPayoff_zero (p0 p1 : ℤ) :
+    centipedeMSZPayoff p0 p1 (0 : Fin 2) = p0 := by
+  simp [centipedeMSZPayoff]
+
+@[simp]
+theorem centipedeMSZPayoff_one (p0 p1 : ℤ) :
+    centipedeMSZPayoff p0 p1 (1 : Fin 2) = p1 := by
+  simp [centipedeMSZPayoff]
+
+/-- A finite Centipede continuation.
+
+`centipedeMSZTree n p0 p1 true` has `n` remaining decision nodes, Player I
+moves next, and stopping immediately gives payoff `(p0, p1)`. Continuing from
+a Player I node changes the next stop payoff to `(p0 - 1, p1 + 3)`;
+continuing from a Player II node changes it to `(p0 + 3, p1 - 1)`.
+
+Thus `centipedeMSZTree 100 1 0 true` is MSZ Example 7.16 / Figure 7.9:
+stage 1 stop payoff `(1,0)`, stage 100 stop payoff `(98,101)`, and final
+all-continue payoff `(101,100)`. -/
+def centipedeMSZTree : ℕ → ℤ → ℤ → Bool → GameTree (Fin 2) ℤ
+  | 0, p0, p1, _ => GameTree.Leaf (centipedeMSZPayoff p0 p1)
+  | n + 1, p0, p1, true =>
+      GameTree.Node (0 : Fin 2)
+        (GameTree.Leaf (centipedeMSZPayoff p0 p1))
+        (List.cons (centipedeMSZTree n (p0 - 1) (p1 + 3) false) List.nil)
+  | n + 1, p0, p1, false =>
+      GameTree.Node (1 : Fin 2)
+        (GameTree.Leaf (centipedeMSZPayoff p0 p1))
+        (List.cons (centipedeMSZTree n (p0 + 3) (p1 - 1) true) List.nil)
+
+/-- The exact 100-stage Centipede game from MSZ Example 7.16. -/
+def centipedeMSZ100Tree : GameTree (Fin 2) ℤ :=
+  centipedeMSZTree 100 1 0 true
+
+/-- The stop-at-every-node strategy immediately reaches the current stop payoff
+    in every MSZ Centipede continuation. -/
+@[simp]
+theorem centipedeMSZStop_outcome_tree (n : ℕ) (p0 p1 : ℤ)
+    (turnIsI : Bool) :
+    GameTree.outcome centipedePrefixStopStrategy
+        (centipedeMSZTree n p0 p1 turnIsI) =
+      centipedeMSZPayoff p0 p1 := by
+  cases n <;> cases turnIsI <;>
+    simp [centipedeMSZTree, centipedePrefixStopStrategy]
+
+/-- Continuing through a terminal MSZ Centipede continuation reaches its
+    terminal payoff. -/
+@[simp]
+theorem centipedeMSZContinue_outcome_tree_zero (p0 p1 : ℤ)
+    (turnIsI : Bool) :
+    GameTree.outcome centipedePrefixContinueStrategy
+        (centipedeMSZTree 0 p0 p1 turnIsI) =
+      centipedeMSZPayoff p0 p1 := by
+  cases turnIsI <;> simp [centipedeMSZTree]
+
+/-- At a Player-I MSZ Centipede node, the all-continue strategy moves to the
+    unique continuation child. -/
+@[simp]
+theorem centipedeMSZContinue_outcome_tree_succ_true (n : ℕ) (p0 p1 : ℤ) :
+    GameTree.outcome centipedePrefixContinueStrategy
+        (centipedeMSZTree (n + 1) p0 p1 true) =
+      GameTree.outcome centipedePrefixContinueStrategy
+        (centipedeMSZTree n (p0 - 1) (p1 + 3) false) := by
+  simp [centipedeMSZTree, centipedePrefixContinueStrategy,
+    centipedePrefixTailOrHead]
+
+/-- At a Player-II MSZ Centipede node, the all-continue strategy moves to the
+    unique continuation child. -/
+@[simp]
+theorem centipedeMSZContinue_outcome_tree_succ_false (n : ℕ) (p0 p1 : ℤ) :
+    GameTree.outcome centipedePrefixContinueStrategy
+        (centipedeMSZTree (n + 1) p0 p1 false) =
+      GameTree.outcome centipedePrefixContinueStrategy
+        (centipedeMSZTree n (p0 + 3) (p1 - 1) true) := by
+  simp [centipedeMSZTree, centipedePrefixContinueStrategy,
+    centipedePrefixTailOrHead]
+
+/-- Deviation that makes player `i` choose the head child at every one of
+    their decision nodes, leaving every other player's choices unchanged. -/
+def centipedeStopAllFor (i : Fin 2) (σ : GameTree.Strategy (Fin 2) ℤ) :
+    GameTree.Strategy (Fin 2) ℤ :=
+  fun m h t => if m = i then ⟨h, by simp⟩ else σ m h t
+
+/-- `centipedeStopAllFor i σ` changes only player `i`'s choices. -/
+theorem centipedeStopAllFor_variant (i : Fin 2)
+    (σ : GameTree.Strategy (Fin 2) ℤ) :
+    GameTree.IVariant i σ (centipedeStopAllFor i σ) := by
+  intro m h t hm
+  simp [centipedeStopAllFor, hm]
+
+/-- In every finite MSZ Centipede continuation, any subgame-perfect strategy
+    profile produces the current stop payoff. This is the payoff form of the
+    backward-induction uniqueness argument. -/
+theorem centipedeMSZSPE_outcome :
+    ∀ (n : ℕ) (p0 p1 : ℤ) (turnIsI : Bool)
+      (σ : GameTree.Strategy (Fin 2) ℤ),
+      GameTree.IsSubgamePerfectOn σ (centipedeMSZTree n p0 p1 turnIsI) →
+        GameTree.outcome σ (centipedeMSZTree n p0 p1 turnIsI) =
+          centipedeMSZPayoff p0 p1 := by
+  intro n
+  induction n with
+  | zero =>
+      intro p0 p1 turnIsI σ _hspe
+      cases turnIsI <;> simp [centipedeMSZTree]
+  | succ n ih =>
+      intro p0 p1 turnIsI σ hspe
+      cases turnIsI
+      · let h : GameTree (Fin 2) ℤ :=
+          GameTree.Leaf (centipedeMSZPayoff p0 p1)
+        let child : GameTree (Fin 2) ℤ :=
+          centipedeMSZTree n (p0 + 3) (p1 - 1) true
+        let t : List (GameTree (Fin 2) ℤ) := List.cons child List.nil
+        change GameTree.outcome σ (GameTree.Node (1 : Fin 2) h t) =
+          centipedeMSZPayoff p0 p1
+        have hchild_spe : GameTree.IsSubgamePerfectOn σ child := by
+          simpa [child] using
+            (hspe.tail_mem (c := child) (by simp [child]))
+        have hchild_out :
+            GameTree.outcome σ child = centipedeMSZPayoff (p0 + 3) (p1 - 1) :=
+          ih (p0 + 3) (p1 - 1) true σ hchild_spe
+        have hchoice : σ (1 : Fin 2) h t = ⟨h, by simp⟩ := by
+          have hchoice_mem : (σ (1 : Fin 2) h t).val ∈ h :: t :=
+            (σ (1 : Fin 2) h t).property
+          rcases List.mem_cons.mp hchoice_mem with hstop | hcontinue_mem
+          · exact Subtype.ext hstop
+          · rcases List.mem_singleton.mp hcontinue_mem with hcontinue
+            let τ : GameTree.Strategy (Fin 2) ℤ :=
+              centipedeStopAllFor (1 : Fin 2) σ
+            have hbad := hspe.toNashAt (1 : Fin 2) τ
+              (centipedeStopAllFor_variant (1 : Fin 2) σ)
+            change GameTree.outcome τ (GameTree.Node (1 : Fin 2) h t) (1 : Fin 2) ≤
+              GameTree.outcome σ (GameTree.Node (1 : Fin 2) h t) (1 : Fin 2) at hbad
+            rw [GameTree.outcome_Node, GameTree.outcome_Node] at hbad
+            simp [τ, centipedeStopAllFor, h, t, child, hcontinue, hchild_out] at hbad
+        rw [GameTree.outcome_Node, hchoice]
+        simp [h]
+      · let h : GameTree (Fin 2) ℤ :=
+          GameTree.Leaf (centipedeMSZPayoff p0 p1)
+        let child : GameTree (Fin 2) ℤ :=
+          centipedeMSZTree n (p0 - 1) (p1 + 3) false
+        let t : List (GameTree (Fin 2) ℤ) := List.cons child List.nil
+        change GameTree.outcome σ (GameTree.Node (0 : Fin 2) h t) =
+          centipedeMSZPayoff p0 p1
+        have hchild_spe : GameTree.IsSubgamePerfectOn σ child := by
+          simpa [child] using
+            (hspe.tail_mem (c := child) (by simp [child]))
+        have hchild_out :
+            GameTree.outcome σ child = centipedeMSZPayoff (p0 - 1) (p1 + 3) :=
+          ih (p0 - 1) (p1 + 3) false σ hchild_spe
+        have hchoice : σ (0 : Fin 2) h t = ⟨h, by simp⟩ := by
+          have hchoice_mem : (σ (0 : Fin 2) h t).val ∈ h :: t :=
+            (σ (0 : Fin 2) h t).property
+          rcases List.mem_cons.mp hchoice_mem with hstop | hcontinue_mem
+          · exact Subtype.ext hstop
+          · rcases List.mem_singleton.mp hcontinue_mem with hcontinue
+            let τ : GameTree.Strategy (Fin 2) ℤ :=
+              centipedeStopAllFor (0 : Fin 2) σ
+            have hbad := hspe.toNashAt (0 : Fin 2) τ
+              (centipedeStopAllFor_variant (0 : Fin 2) σ)
+            change GameTree.outcome τ (GameTree.Node (0 : Fin 2) h t) (0 : Fin 2) ≤
+              GameTree.outcome σ (GameTree.Node (0 : Fin 2) h t) (0 : Fin 2) at hbad
+            rw [GameTree.outcome_Node, GameTree.outcome_Node] at hbad
+            simp [τ, centipedeStopAllFor, h, t, child, hcontinue, hchild_out] at hbad
+        rw [GameTree.outcome_Node, hchoice]
+        simp [h]
+
+/-- At every nonterminal Player-I MSZ Centipede continuation, any
+    subgame-perfect strategy must choose Stop at the root. -/
+theorem centipedeMSZSPE_root_stop_true (n : ℕ) (p0 p1 : ℤ)
+    {σ : GameTree.Strategy (Fin 2) ℤ}
+    (hspe : GameTree.IsSubgamePerfectOn σ
+      (centipedeMSZTree (n + 1) p0 p1 true)) :
+    σ (0 : Fin 2) (GameTree.Leaf (centipedeMSZPayoff p0 p1))
+        (List.cons (centipedeMSZTree n (p0 - 1) (p1 + 3) false) List.nil) =
+      ⟨GameTree.Leaf (centipedeMSZPayoff p0 p1), by simp⟩ := by
+  let h : GameTree (Fin 2) ℤ := GameTree.Leaf (centipedeMSZPayoff p0 p1)
+  let child : GameTree (Fin 2) ℤ :=
+    centipedeMSZTree n (p0 - 1) (p1 + 3) false
+  let t : List (GameTree (Fin 2) ℤ) := List.cons child List.nil
+  change σ (0 : Fin 2) h t = ⟨h, by simp⟩
+  have hchild_spe : GameTree.IsSubgamePerfectOn σ child := by
+    simpa [child] using
+      (hspe.tail_mem (c := child) (by simp [child]))
+  have hchild_out :
+      GameTree.outcome σ child = centipedeMSZPayoff (p0 - 1) (p1 + 3) :=
+    centipedeMSZSPE_outcome n (p0 - 1) (p1 + 3) false σ hchild_spe
+  have hchoice_mem : (σ (0 : Fin 2) h t).val ∈ h :: t :=
+    (σ (0 : Fin 2) h t).property
+  rcases List.mem_cons.mp hchoice_mem with hstop | hcontinue_mem
+  · exact Subtype.ext hstop
+  · rcases List.mem_singleton.mp hcontinue_mem with hcontinue
+    let τ : GameTree.Strategy (Fin 2) ℤ := centipedeStopAllFor (0 : Fin 2) σ
+    have hbad := hspe.toNashAt (0 : Fin 2) τ
+      (centipedeStopAllFor_variant (0 : Fin 2) σ)
+    change GameTree.outcome τ (GameTree.Node (0 : Fin 2) h t) (0 : Fin 2) ≤
+      GameTree.outcome σ (GameTree.Node (0 : Fin 2) h t) (0 : Fin 2) at hbad
+    rw [GameTree.outcome_Node, GameTree.outcome_Node] at hbad
+    simp [τ, centipedeStopAllFor, h, t, child, hcontinue, hchild_out] at hbad
+
+/-- At every nonterminal Player-II MSZ Centipede continuation, any
+    subgame-perfect strategy must choose Stop at the root. -/
+theorem centipedeMSZSPE_root_stop_false (n : ℕ) (p0 p1 : ℤ)
+    {σ : GameTree.Strategy (Fin 2) ℤ}
+    (hspe : GameTree.IsSubgamePerfectOn σ
+      (centipedeMSZTree (n + 1) p0 p1 false)) :
+    σ (1 : Fin 2) (GameTree.Leaf (centipedeMSZPayoff p0 p1))
+        (List.cons (centipedeMSZTree n (p0 + 3) (p1 - 1) true) List.nil) =
+      ⟨GameTree.Leaf (centipedeMSZPayoff p0 p1), by simp⟩ := by
+  let h : GameTree (Fin 2) ℤ := GameTree.Leaf (centipedeMSZPayoff p0 p1)
+  let child : GameTree (Fin 2) ℤ :=
+    centipedeMSZTree n (p0 + 3) (p1 - 1) true
+  let t : List (GameTree (Fin 2) ℤ) := List.cons child List.nil
+  change σ (1 : Fin 2) h t = ⟨h, by simp⟩
+  have hchild_spe : GameTree.IsSubgamePerfectOn σ child := by
+    simpa [child] using
+      (hspe.tail_mem (c := child) (by simp [child]))
+  have hchild_out :
+      GameTree.outcome σ child = centipedeMSZPayoff (p0 + 3) (p1 - 1) :=
+    centipedeMSZSPE_outcome n (p0 + 3) (p1 - 1) true σ hchild_spe
+  have hchoice_mem : (σ (1 : Fin 2) h t).val ∈ h :: t :=
+    (σ (1 : Fin 2) h t).property
+  rcases List.mem_cons.mp hchoice_mem with hstop | hcontinue_mem
+  · exact Subtype.ext hstop
+  · rcases List.mem_singleton.mp hcontinue_mem with hcontinue
+    let τ : GameTree.Strategy (Fin 2) ℤ := centipedeStopAllFor (1 : Fin 2) σ
+    have hbad := hspe.toNashAt (1 : Fin 2) τ
+      (centipedeStopAllFor_variant (1 : Fin 2) σ)
+    change GameTree.outcome τ (GameTree.Node (1 : Fin 2) h t) (1 : Fin 2) ≤
+      GameTree.outcome σ (GameTree.Node (1 : Fin 2) h t) (1 : Fin 2) at hbad
+    rw [GameTree.outcome_Node, GameTree.outcome_Node] at hbad
+    simp [τ, centipedeStopAllFor, h, t, child, hcontinue, hchild_out] at hbad
+
+/-- If Player I deviates by continuing, the next Player II node is unchanged
+    under a Player-I-only deviation, so the continuation immediately stops with
+    Player I payoff `p0 - 1`. -/
+theorem centipedeMSZPlayerIContinue_variant_outcome (n : ℕ) (p0 p1 : ℤ)
+    {σ' : GameTree.Strategy (Fin 2) ℤ}
+    (hiv : GameTree.IVariant (0 : Fin 2) centipedePrefixStopStrategy σ') :
+    GameTree.outcome σ' (centipedeMSZTree n (p0 - 1) (p1 + 3) false)
+        (0 : Fin 2) = p0 - 1 := by
+  cases n with
+  | zero =>
+      simp [centipedeMSZTree, centipedeMSZPayoff]
+  | succ n =>
+      let h : GameTree (Fin 2) ℤ :=
+        GameTree.Leaf (centipedeMSZPayoff (p0 - 1) (p1 + 3))
+      let t : List (GameTree (Fin 2) ℤ) :=
+        List.cons (centipedeMSZTree n ((p0 - 1) + 3) ((p1 + 3) - 1) true)
+          List.nil
+      change GameTree.outcome σ' (GameTree.Node (1 : Fin 2) h t)
+          (0 : Fin 2) = p0 - 1
+      have hsame :
+          σ' (1 : Fin 2) h t =
+            centipedePrefixStopStrategy (1 : Fin 2) h t :=
+        (hiv (1 : Fin 2) h t (by decide)).symm
+      rw [GameTree.outcome_Node, hsame]
+      simp [h, t, centipedePrefixStopStrategy]
+
+/-- If Player II deviates by continuing, the next Player I node is unchanged
+    under a Player-II-only deviation, so the continuation immediately stops with
+    Player II payoff `p1 - 1`. -/
+theorem centipedeMSZPlayerIIContinue_variant_outcome (n : ℕ) (p0 p1 : ℤ)
+    {σ' : GameTree.Strategy (Fin 2) ℤ}
+    (hiv : GameTree.IVariant (1 : Fin 2) centipedePrefixStopStrategy σ') :
+    GameTree.outcome σ' (centipedeMSZTree n (p0 + 3) (p1 - 1) true)
+        (1 : Fin 2) = p1 - 1 := by
+  cases n with
+  | zero =>
+      simp [centipedeMSZTree, centipedeMSZPayoff]
+  | succ n =>
+      let h : GameTree (Fin 2) ℤ :=
+        GameTree.Leaf (centipedeMSZPayoff (p0 + 3) (p1 - 1))
+      let t : List (GameTree (Fin 2) ℤ) :=
+        List.cons (centipedeMSZTree n ((p0 + 3) - 1) ((p1 - 1) + 3) false)
+          List.nil
+      change GameTree.outcome σ' (GameTree.Node (0 : Fin 2) h t)
+          (1 : Fin 2) = p1 - 1
+      have hsame :
+          σ' (0 : Fin 2) h t =
+            centipedePrefixStopStrategy (0 : Fin 2) h t :=
+        (hiv (0 : Fin 2) h t (by decide)).symm
+      rw [GameTree.outcome_Node, hsame]
+      simp [h, t, centipedePrefixStopStrategy]
+
+/-- Stopping is Nash at the root of every nonterminal MSZ Centipede
+    continuation. -/
+theorem centipedeMSZStop_isNashAt_tree_succ (n : ℕ) (p0 p1 : ℤ)
+    (turnIsI : Bool) :
+    GameTree.IsNashAt centipedePrefixStopStrategy
+      (centipedeMSZTree (n + 1) p0 p1 turnIsI) := by
+  cases turnIsI
+  · let h : GameTree (Fin 2) ℤ :=
+      GameTree.Leaf (centipedeMSZPayoff p0 p1)
+    let t : List (GameTree (Fin 2) ℤ) :=
+      List.cons (centipedeMSZTree n (p0 + 3) (p1 - 1) true) List.nil
+    change GameTree.IsNashAt centipedePrefixStopStrategy
+      (GameTree.Node (1 : Fin 2) h t)
+    intro i σ' hiv
+    fin_cases i
+    · have hsame :
+          σ' (1 : Fin 2) h t =
+            centipedePrefixStopStrategy (1 : Fin 2) h t :=
+        (hiv (1 : Fin 2) h t (by decide)).symm
+      rw [GameTree.outcome_Node, GameTree.outcome_Node, hsame]
+      simp [h, t, centipedePrefixStopStrategy]
+    · have hchoice_mem :
+          (σ' (1 : Fin 2) h t).val ∈ h :: t :=
+        (σ' (1 : Fin 2) h t).property
+      rcases List.mem_cons.mp hchoice_mem with hchoice | hchoice_tail
+      · rw [GameTree.outcome_Node, hchoice, GameTree.outcome_Node]
+        simp [h, t, centipedePrefixStopStrategy]
+      · rcases List.mem_singleton.mp hchoice_tail with hchoice
+        rw [GameTree.outcome_Node, hchoice, GameTree.outcome_Node]
+        change GameTree.outcome σ'
+            (centipedeMSZTree n (p0 + 3) (p1 - 1) true) (1 : Fin 2) ≤
+          GameTree.outcome centipedePrefixStopStrategy
+            (centipedePrefixStopStrategy (1 : Fin 2) h t).val (1 : Fin 2)
+        rw [centipedeMSZPlayerIIContinue_variant_outcome n p0 p1 hiv]
+        simp [h, t, centipedePrefixStopStrategy]
+  · let h : GameTree (Fin 2) ℤ :=
+      GameTree.Leaf (centipedeMSZPayoff p0 p1)
+    let t : List (GameTree (Fin 2) ℤ) :=
+      List.cons (centipedeMSZTree n (p0 - 1) (p1 + 3) false) List.nil
+    change GameTree.IsNashAt centipedePrefixStopStrategy
+      (GameTree.Node (0 : Fin 2) h t)
+    intro i σ' hiv
+    fin_cases i
+    · have hchoice_mem :
+          (σ' (0 : Fin 2) h t).val ∈ h :: t :=
+        (σ' (0 : Fin 2) h t).property
+      rcases List.mem_cons.mp hchoice_mem with hchoice | hchoice_tail
+      · rw [GameTree.outcome_Node, hchoice, GameTree.outcome_Node]
+        simp [h, t, centipedePrefixStopStrategy]
+      · rcases List.mem_singleton.mp hchoice_tail with hchoice
+        rw [GameTree.outcome_Node, hchoice, GameTree.outcome_Node]
+        change GameTree.outcome σ'
+            (centipedeMSZTree n (p0 - 1) (p1 + 3) false) (0 : Fin 2) ≤
+          GameTree.outcome centipedePrefixStopStrategy
+            (centipedePrefixStopStrategy (0 : Fin 2) h t).val (0 : Fin 2)
+        rw [centipedeMSZPlayerIContinue_variant_outcome n p0 p1 hiv]
+        simp [h, t, centipedePrefixStopStrategy]
+    · have hsame :
+          σ' (0 : Fin 2) h t =
+            centipedePrefixStopStrategy (0 : Fin 2) h t :=
+        (hiv (0 : Fin 2) h t (by decide)).symm
+      rw [GameTree.outcome_Node, GameTree.outcome_Node, hsame]
+      simp [h, t, centipedePrefixStopStrategy]
+
+/-- Stopping at every decision node is subgame-perfect in every finite MSZ
+    Centipede continuation. This is the backward-induction argument used in
+    MSZ Example 7.16, stated recursively. -/
+theorem centipedeMSZStop_isSubgamePerfectOn_tree :
+    ∀ (n : ℕ) (p0 p1 : ℤ) (turnIsI : Bool),
+      GameTree.IsSubgamePerfectOn centipedePrefixStopStrategy
+        (centipedeMSZTree n p0 p1 turnIsI) := by
+  intro n
+  induction n with
+  | zero =>
+      intro p0 p1 turnIsI
+      cases turnIsI <;>
+        simpa [centipedeMSZTree] using
+          (GameTree.isSubgamePerfectOn_Leaf centipedePrefixStopStrategy
+            (centipedeMSZPayoff p0 p1))
+  | succ n ih =>
+      intro p0 p1 turnIsI
+      cases turnIsI
+      · change GameTree.IsSubgamePerfectOn centipedePrefixStopStrategy
+          (GameTree.Node (1 : Fin 2)
+            (GameTree.Leaf (centipedeMSZPayoff p0 p1))
+            (List.cons (centipedeMSZTree n (p0 + 3) (p1 - 1) true) List.nil))
+        rw [GameTree.isSubgamePerfectOn_Node_iff]
+        refine ⟨centipedeMSZStop_isNashAt_tree_succ n p0 p1 false, ?_, ?_⟩
+        · exact GameTree.isSubgamePerfectOn_Leaf centipedePrefixStopStrategy
+            (centipedeMSZPayoff p0 p1)
+        · intro c hc
+          rcases List.mem_singleton.mp hc with rfl
+          exact ih (p0 + 3) (p1 - 1) true
+      · change GameTree.IsSubgamePerfectOn centipedePrefixStopStrategy
+          (GameTree.Node (0 : Fin 2)
+            (GameTree.Leaf (centipedeMSZPayoff p0 p1))
+            (List.cons (centipedeMSZTree n (p0 - 1) (p1 + 3) false) List.nil))
+        rw [GameTree.isSubgamePerfectOn_Node_iff]
+        refine ⟨centipedeMSZStop_isNashAt_tree_succ n p0 p1 true, ?_, ?_⟩
+        · exact GameTree.isSubgamePerfectOn_Leaf centipedePrefixStopStrategy
+            (centipedeMSZPayoff p0 p1)
+        · intro c hc
+          rcases List.mem_singleton.mp hc with rfl
+          exact ih (p0 - 1) (p1 + 3) false
+
+/-- In the exact 100-stage MSZ Centipede game, stopping at every decision node
+    is subgame-perfect. -/
+theorem centipedeMSZ100_stop_isSubgamePerfectOn :
+    GameTree.IsSubgamePerfectOn centipedePrefixStopStrategy
+      centipedeMSZ100Tree := by
+  simpa [centipedeMSZ100Tree] using
+    centipedeMSZStop_isSubgamePerfectOn_tree 100 1 0 true
+
+/-- The same stop-at-every-node strategy is Nash at the root of the exact
+    100-stage MSZ Centipede game. -/
+theorem centipedeMSZ100_stop_isNashAt :
+    GameTree.IsNashAt centipedePrefixStopStrategy centipedeMSZ100Tree :=
+  centipedeMSZ100_stop_isSubgamePerfectOn.toNashAt
+
+/-- The subgame-perfect stop-at-every-node outcome in the exact 100-stage MSZ
+    Centipede game is `(1, 0)`, as in the textbook backward-induction
+    conclusion. -/
+theorem centipedeMSZ100_stop_outcome :
+    GameTree.outcome centipedePrefixStopStrategy centipedeMSZ100Tree (0 : Fin 2) = 1 ∧
+      GameTree.outcome centipedePrefixStopStrategy centipedeMSZ100Tree (1 : Fin 2) = 0 := by
+  simp [centipedeMSZ100Tree]
+
+/-- If both players continue through every decision node in the exact
+    100-stage MSZ Centipede game, the terminal payoff is `(101, 100)`. -/
+theorem centipedeMSZ100_continue_outcome :
+    GameTree.outcome centipedePrefixContinueStrategy centipedeMSZ100Tree (0 : Fin 2) = 101 ∧
+      GameTree.outcome centipedePrefixContinueStrategy centipedeMSZ100Tree (1 : Fin 2) = 100 := by
+  simp [centipedeMSZ100Tree]
+
 /-- The finite no-chance Arena prefix extracts to the corresponding
     perfect-information `GameTree`. -/
 theorem centipedePrefixArena_extracts_tree :
@@ -209,7 +812,9 @@ theorem centipedePrefixArena_extracts_tree :
       centipedePrefixArena.init centipedePrefixTree := by
   change ExtensiveGame.ExtractsGameTree centipedePrefixArena
     PrefixState.root centipedePrefixTree
-  unfold centipedePrefixTree
+  unfold centipedePrefixTree centipedePrefixStop0Leaf
+    centipedePrefixContinuationTree centipedePrefixStop1Leaf
+    centipedePrefixContinue1Leaf
   apply ExtensiveGame.ExtractsGameTree.node
     (head := PrefixState.PrefixAction.stopRoot)
     (tail := List.cons PrefixState.PrefixAction.continueRoot List.nil)

--- a/EconCSLib/Examples/EntryDeterrence.lean
+++ b/EconCSLib/Examples/EntryDeterrence.lean
@@ -4,10 +4,16 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 
 import EconCSLib.GameTheory.ExtensiveGame.Basic
+import EconCSLib.GameTheory.ExtensiveGame.FiniteArenaExtraction
+import EconCSLib.GameTheory.ExtensiveGame.GameTreeNE
+import Mathlib.Data.Fin.Basic
+import Mathlib.Data.Fintype.Basic
 import Mathlib.Data.Rat.Cast.Defs
+import Mathlib.Tactic.FinCases
+import Mathlib.Tactic.NormNum
 
 /-!
-# EconCSLib.Examples.EntryDeterrence
+# Examples.EntryDeterrence
 
 The Entry Deterrence game: a classic 2-player extensive-form game.
 
@@ -102,3 +108,263 @@ example : ED.payoff stayOut 0 = 1 := rfl
 example : ED.payoff stayOut 1 = 3 := rfl
 example : ED.payoff fight 0 = 0 := rfl
 example : ED.payoff fight 1 = 0 := rfl
+
+/-! ### Finite-tree equilibrium view
+
+The following `GameTree` version formalizes the equilibrium-refinement point
+made in MSZ Example 7.1: staying out while the incumbent threatens to fight is
+a Nash equilibrium at the root, but it is not subgame-perfect because fighting
+is not optimal in the reached subgame. Entering and accommodating is
+subgame-perfect.
+-/
+
+namespace Examples.EntryDeterrence
+
+open GameTree
+
+/-- Player `0` is the entrant; player `1` is the incumbent. -/
+abbrev Player := Fin 2
+
+def entrant : Player := 0
+def incumbent : Player := 1
+
+/-- Terminal payoff vector for the entrant and incumbent. -/
+def payoffVector (entrantPayoff incumbentPayoff : ℚ) : Player → ℚ
+  | ⟨0, _⟩ => entrantPayoff
+  | ⟨1, _⟩ => incumbentPayoff
+
+def accommodateLeaf : GameTree Player ℚ := Leaf (payoffVector 2 2)
+def fightLeaf : GameTree Player ℚ := Leaf (payoffVector 0 0)
+def stayOutLeaf : GameTree Player ℚ := Leaf (payoffVector 1 3)
+
+/-- The incumbent's subgame after entry. -/
+def entryDeterrenceSubgame : GameTree Player ℚ :=
+  Node incumbent accommodateLeaf (List.cons fightLeaf List.nil)
+
+/-- The finite perfect-information entry-deterrence tree from MSZ Example 7.1. -/
+def entryDeterrenceTree : GameTree Player ℚ :=
+  Node entrant entryDeterrenceSubgame (List.cons stayOutLeaf List.nil)
+
+/-- Select the first tail child when one exists; otherwise select the head.
+    On the binary trees in this file this means "select the right branch". -/
+def firstTailOrHead (h : GameTree Player ℚ) :
+    (t : List (GameTree Player ℚ)) → { c : GameTree Player ℚ // c ∈ h :: t }
+  | [] => ⟨h, by simp⟩
+  | c :: _ => ⟨c, by simp⟩
+
+/-- The strategy profile `(Enter, Accommodate)`. -/
+def enterAccommodateStrategy : Strategy Player ℚ :=
+  fun _ h _ => ⟨h, by simp⟩
+
+/-- The strategy profile `(StayOut, Fight)`. -/
+def stayOutFightStrategy : Strategy Player ℚ :=
+  fun _ h t => firstTailOrHead h t
+
+/-- The strategy profile `(StayOut, Accommodate)`, used as an incumbent
+    deviation in the off-path subgame. -/
+def stayOutAccommodateStrategy : Strategy Player ℚ :=
+  fun m h t =>
+    if m = incumbent then ⟨h, by simp⟩ else firstTailOrHead h t
+
+theorem entryDeterrenceSubgame_subtree :
+    Subtree entryDeterrenceSubgame entryDeterrenceTree := by
+  simp [entryDeterrenceTree]
+  exact Subtree.head entrant entryDeterrenceSubgame
+    (List.cons stayOutLeaf List.nil)
+
+theorem entryDeterrenceSubgame_properSubgame :
+    ProperSubgame entryDeterrenceSubgame entryDeterrenceTree := by
+  simp [entryDeterrenceTree]
+  exact ProperSubgame.head entrant entryDeterrenceSubgame
+    (List.cons stayOutLeaf List.nil)
+
+theorem stayOutFight_to_stayOutAccommodate_incumbentVariant :
+    IVariant incumbent stayOutFightStrategy stayOutAccommodateStrategy := by
+  intro m h t hm
+  simp [stayOutFightStrategy, stayOutAccommodateStrategy, hm]
+
+theorem stayOutFight_isNashAt_entryDeterrence :
+    IsNashAt stayOutFightStrategy entryDeterrenceTree := by
+  intro i σ' hiv
+  fin_cases i
+  · have hroot_mem :
+        (σ' entrant entryDeterrenceSubgame (List.cons stayOutLeaf List.nil)).val ∈
+          entryDeterrenceSubgame :: List.cons stayOutLeaf List.nil :=
+      (σ' entrant entryDeterrenceSubgame (List.cons stayOutLeaf List.nil)).property
+    rcases List.mem_cons.mp hroot_mem with hroot | hroot_tail
+    · have hsub_same :
+          σ' incumbent accommodateLeaf (List.cons fightLeaf List.nil) =
+            stayOutFightStrategy incumbent accommodateLeaf
+              (List.cons fightLeaf List.nil) :=
+        (hiv incumbent accommodateLeaf (List.cons fightLeaf List.nil) (by decide)).symm
+      rw [entryDeterrenceTree, outcome_Node]
+      rw [hroot]
+      rw [entryDeterrenceSubgame, outcome_Node]
+      rw [hsub_same]
+      simp [stayOutFightStrategy, firstTailOrHead, fightLeaf, stayOutLeaf,
+        payoffVector]
+    · rcases List.mem_singleton.mp hroot_tail with hroot
+      rw [entryDeterrenceTree, outcome_Node]
+      rw [hroot]
+      simp [stayOutFightStrategy, firstTailOrHead, stayOutLeaf, payoffVector]
+  · have hroot_same :
+        σ' entrant entryDeterrenceSubgame (List.cons stayOutLeaf List.nil) =
+          stayOutFightStrategy entrant entryDeterrenceSubgame
+            (List.cons stayOutLeaf List.nil) :=
+      (hiv entrant entryDeterrenceSubgame (List.cons stayOutLeaf List.nil) (by decide)).symm
+    rw [entryDeterrenceTree, outcome_Node]
+    rw [hroot_same]
+    simp [stayOutFightStrategy, firstTailOrHead, stayOutLeaf, payoffVector]
+
+theorem stayOutFight_not_isNashAt_entrySubgame :
+    ¬ IsNashAt stayOutFightStrategy entryDeterrenceSubgame := by
+  intro hnash
+  have hbad := hnash incumbent stayOutAccommodateStrategy
+    stayOutFight_to_stayOutAccommodate_incumbentVariant
+  have hle : (2 : ℚ) ≤ 0 := by
+    simpa [entryDeterrenceSubgame, stayOutFightStrategy,
+      stayOutAccommodateStrategy, firstTailOrHead, accommodateLeaf, fightLeaf,
+      payoffVector, incumbent] using hbad
+  norm_num at hle
+
+theorem stayOutFight_not_isSubgamePerfectOn_entryDeterrence :
+    ¬ IsSubgamePerfectOn stayOutFightStrategy entryDeterrenceTree := by
+  intro hspe
+  exact stayOutFight_not_isNashAt_entrySubgame
+    (hspe.toNashAt_of_subtree entryDeterrenceSubgame_subtree)
+
+theorem enterAccommodate_isNashAt_entrySubgame :
+    IsNashAt enterAccommodateStrategy entryDeterrenceSubgame := by
+  intro i σ' hiv
+  fin_cases i
+  · have hroot_same :
+        σ' incumbent accommodateLeaf (List.cons fightLeaf List.nil) =
+          enterAccommodateStrategy incumbent accommodateLeaf
+            (List.cons fightLeaf List.nil) :=
+      (hiv incumbent accommodateLeaf (List.cons fightLeaf List.nil) (by decide)).symm
+    rw [entryDeterrenceSubgame, outcome_Node]
+    rw [hroot_same]
+    simp [enterAccommodateStrategy, accommodateLeaf, payoffVector]
+  · have hroot_mem :
+        (σ' incumbent accommodateLeaf (List.cons fightLeaf List.nil)).val ∈
+          accommodateLeaf :: List.cons fightLeaf List.nil :=
+      (σ' incumbent accommodateLeaf (List.cons fightLeaf List.nil)).property
+    rcases List.mem_cons.mp hroot_mem with hroot | hroot_tail
+    · rw [entryDeterrenceSubgame, outcome_Node]
+      rw [hroot]
+      simp [enterAccommodateStrategy, accommodateLeaf, payoffVector]
+    · rcases List.mem_singleton.mp hroot_tail with hroot
+      rw [entryDeterrenceSubgame, outcome_Node]
+      rw [hroot]
+      simp [enterAccommodateStrategy, fightLeaf, accommodateLeaf, payoffVector]
+
+theorem enterAccommodate_isSubgamePerfectOn_entrySubgame :
+    IsSubgamePerfectOn enterAccommodateStrategy entryDeterrenceSubgame := by
+  change IsSubgamePerfectOn enterAccommodateStrategy
+    (Node incumbent accommodateLeaf (List.cons fightLeaf List.nil))
+  rw [isSubgamePerfectOn_Node_iff]
+  refine ⟨enterAccommodate_isNashAt_entrySubgame, ?_, ?_⟩
+  · exact isSubgamePerfectOn_Leaf enterAccommodateStrategy (payoffVector 2 2)
+  · intro c hmem
+    rcases List.mem_singleton.mp hmem with rfl
+    exact isSubgamePerfectOn_Leaf enterAccommodateStrategy (payoffVector 0 0)
+
+theorem enterAccommodate_isNashAt_entryDeterrence :
+    IsNashAt enterAccommodateStrategy entryDeterrenceTree := by
+  intro i σ' hiv
+  fin_cases i
+  · have hroot_mem :
+        (σ' entrant entryDeterrenceSubgame (List.cons stayOutLeaf List.nil)).val ∈
+          entryDeterrenceSubgame :: List.cons stayOutLeaf List.nil :=
+      (σ' entrant entryDeterrenceSubgame (List.cons stayOutLeaf List.nil)).property
+    rcases List.mem_cons.mp hroot_mem with hroot | hroot_tail
+    · have hsub_same :
+          σ' incumbent accommodateLeaf (List.cons fightLeaf List.nil) =
+            enterAccommodateStrategy incumbent accommodateLeaf
+              (List.cons fightLeaf List.nil) :=
+        (hiv incumbent accommodateLeaf (List.cons fightLeaf List.nil) (by decide)).symm
+      rw [entryDeterrenceTree, outcome_Node]
+      rw [hroot]
+      rw [entryDeterrenceSubgame, outcome_Node]
+      rw [hsub_same]
+      simp [enterAccommodateStrategy, accommodateLeaf, stayOutLeaf, payoffVector]
+    · rcases List.mem_singleton.mp hroot_tail with hroot
+      rw [entryDeterrenceTree, outcome_Node]
+      rw [hroot]
+      simp [enterAccommodateStrategy, entryDeterrenceSubgame, stayOutLeaf,
+        accommodateLeaf, payoffVector]
+  · have hroot_same :
+        σ' entrant entryDeterrenceSubgame (List.cons stayOutLeaf List.nil) =
+          enterAccommodateStrategy entrant entryDeterrenceSubgame
+            (List.cons stayOutLeaf List.nil) :=
+      (hiv entrant entryDeterrenceSubgame (List.cons stayOutLeaf List.nil) (by decide)).symm
+    have hsub_mem :
+        (σ' incumbent accommodateLeaf (List.cons fightLeaf List.nil)).val ∈
+          accommodateLeaf :: List.cons fightLeaf List.nil :=
+      (σ' incumbent accommodateLeaf (List.cons fightLeaf List.nil)).property
+    rcases List.mem_cons.mp hsub_mem with hsub | hsub_tail
+    · rw [entryDeterrenceTree, outcome_Node]
+      rw [hroot_same]
+      simp [enterAccommodateStrategy]
+      rw [entryDeterrenceSubgame, outcome_Node]
+      rw [hsub]
+      simp [enterAccommodateStrategy, accommodateLeaf, payoffVector]
+    · rcases List.mem_singleton.mp hsub_tail with hsub
+      rw [entryDeterrenceTree, outcome_Node]
+      rw [hroot_same]
+      simp [enterAccommodateStrategy]
+      rw [entryDeterrenceSubgame, outcome_Node]
+      rw [hsub]
+      simp [enterAccommodateStrategy, fightLeaf, accommodateLeaf, payoffVector]
+
+theorem enterAccommodate_isSubgamePerfectOn_entryDeterrence :
+    IsSubgamePerfectOn enterAccommodateStrategy entryDeterrenceTree := by
+  change IsSubgamePerfectOn enterAccommodateStrategy
+    (Node entrant entryDeterrenceSubgame (List.cons stayOutLeaf List.nil))
+  rw [isSubgamePerfectOn_Node_iff]
+  refine ⟨enterAccommodate_isNashAt_entryDeterrence, ?_, ?_⟩
+  · exact enterAccommodate_isSubgamePerfectOn_entrySubgame
+  · intro c hmem
+    rcases List.mem_singleton.mp hmem with rfl
+    exact isSubgamePerfectOn_Leaf enterAccommodateStrategy (payoffVector 1 3)
+
+/-- The Arena-style entry-deterrence game extracts to the finite
+    perfect-information `GameTree` used by the equilibrium-refinement proofs. -/
+theorem entryDeterrenceArena_extracts_tree :
+    ExtensiveGame.ExtractsGameTree ED ED.init entryDeterrenceTree := by
+  change ExtensiveGame.ExtractsGameTree ED root entryDeterrenceTree
+  unfold entryDeterrenceTree entryDeterrenceSubgame accommodateLeaf fightLeaf
+    stayOutLeaf
+  apply ExtensiveGame.ExtractsGameTree.node
+    (head := Enter)
+    (tail := List.cons StayOut List.nil)
+  · rfl
+  · intro a
+    cases a <;> simp
+  · apply ExtensiveGame.ExtractsGameTree.node
+      (head := Accommodate)
+      (tail := List.cons Fight List.nil)
+    · rfl
+    · intro a
+      cases a <;> simp
+    · convert ExtensiveGame.ExtractsGameTree.leaf (G := ED) accommodate ?_
+      · funext i
+        fin_cases i <;> rfl
+      · change IsEmpty (edAction accommodate)
+        infer_instance
+    · apply ExtensiveGame.ExtractsGameTreeList.cons
+      · convert ExtensiveGame.ExtractsGameTree.leaf (G := ED) fight ?_
+        · funext i
+          fin_cases i <;> rfl
+        · change IsEmpty (edAction fight)
+          infer_instance
+      · apply ExtensiveGame.ExtractsGameTreeList.nil
+  · apply ExtensiveGame.ExtractsGameTreeList.cons
+    · convert ExtensiveGame.ExtractsGameTree.leaf (G := ED) stayOut ?_
+      · funext i
+        fin_cases i <;> rfl
+      · change IsEmpty (edAction stayOut)
+        infer_instance
+    · apply ExtensiveGame.ExtractsGameTreeList.nil
+
+end Examples.EntryDeterrence

--- a/EconCSLib/Examples/SimpleGameTree.lean
+++ b/EconCSLib/Examples/SimpleGameTree.lean
@@ -8,7 +8,7 @@ import EconCSLib.GameTheory.ExtensiveGame.GameTreeNE
 import EconCSLib.GameTheory.ExtensiveGame.GameTreeStrategicForm
 
 /-!
-# EconCSLib.Examples.SimpleGameTree
+# Examples.SimpleGameTree
 
 A sample 2-player zero-sum perfect-info game expressed in the
 `GameTree` framework, used to smoke-test `value`, `Kuhn_exists_SPE`,
@@ -57,17 +57,15 @@ def sample : GameTree Player ℚ :=
       (List.cons (Leaf (zeroSumLeaf (-10))) List.nil))
     (List.cons (Leaf (zeroSumLeaf 3)) List.nil)
 
--- Sanity: the game is well-typed.
+/-- Player A's proper subgame inside `sample`. -/
+def sampleLeftSubgame : GameTree Player ℚ :=
+  Node (0 : Player)
+    (Leaf (zeroSumLeaf 10))
+    (List.cons (Leaf (zeroSumLeaf (-10))) List.nil)
+
+-- Sanity: the game is well-typed. (Deeper `#eval` checks are blocked by
+-- the noncomputable `value` relying on classical choice.)
 example : GameTree Player ℚ := sample
-
--- `value` is computable (backward induction over the decidable order `≤` on `ℚ`),
--- so the value evaluates and is machine-checkable on this concrete game.
-#eval value₀ sample          -- 3  (B picks min{10, 3} = 3)
-#eval value sample 0         -- 3
-#eval value sample 1         -- -3
-
-/-- The player-0 value of the sample is `3`, checked by computation. -/
-example : value₀ sample = 3 := by decide
 
 /-- The zero-sum predicate holds on the sample game. -/
 theorem sample_zero_sum : IsZeroSum sample := by
@@ -76,32 +74,19 @@ theorem sample_zero_sum : IsZeroSum sample := by
 /-- **Existence of an SPE** for the sample game (via `Kuhn_exists_SPE`). -/
 example : ∃ σ : Strategy Player ℚ, IsSubgamePerfect σ := Kuhn_exists_SPE
 
-/-- Pure root-scoped SPE existence for the sample (Kuhn's theorem; no zero-sum
-    hypothesis required). -/
-theorem sample_zermelo_spe : ∃ σ : Strategy Player ℚ, IsSubgamePerfectOn σ sample :=
-  zermelo_exists_pure_SPE sample
+/-- Zermelo-style pure SPE existence for the zero-sum sample. -/
+theorem sample_zermelo_spe : ∃ σ : Strategy Player ℚ, IsSubgamePerfect σ :=
+  zermelo_exists_pure_SPE sample sample_zero_sum
 
-/-- Pure root Nash existence for the sample (Kuhn's theorem). -/
+/-- Zermelo-style pure root Nash existence for the zero-sum sample. -/
 theorem sample_zermelo_ne :
     ∃ σ : Strategy Player ℚ, GameTree.IsNashEquilibrium σ sample :=
-  zermelo_exists_pure_NE sample
-
-/-- **Zermelo determinacy on the sample**: `optStrategy` is a saddle with value
-    `value₀ sample` — player 0 secures it, player 1 caps it. This is the result
-    that genuinely uses the zero-sum hypothesis `sample_zero_sum`. -/
-theorem sample_zermelo_determinacy :
-    (∀ σ' : Strategy Player ℚ, IVariant (1 : Player) optStrategy σ' →
-        value₀ sample ≤ outcome σ' sample 0) ∧
-    (∀ σ' : Strategy Player ℚ, IVariant (0 : Player) optStrategy σ' →
-        outcome σ' sample 0 ≤ value₀ sample) :=
-  zermelo_determinacy sample sample_zero_sum
+  zermelo_exists_pure_NE sample sample_zero_sum
 
 /-- A one-leaf game has only its root as a subgame. -/
 theorem leaf_hasOnlyRootSubgames (p : Player → ℚ) :
-    HasOnlyRootSubgames (Leaf p : GameTree Player ℚ) := by
-  intro s hsub
-  cases hsub
-  rfl
+    HasOnlyRootSubgames (Leaf p : GameTree Player ℚ) :=
+  hasOnlyRootSubgames_Leaf p
 
 /-- On a game with no proper subgames, root Nash already gives the corresponding
     root-scoped subgame-perfect condition. This instantiates the pure finite-tree
@@ -118,7 +103,106 @@ theorem sample_value_zero_sum : (value sample) 0 + (value sample) 1 = 0 :=
 /-- The backward-induction strategy is subgame-perfect on the sample root. -/
 theorem sample_optStrategy_spe_on :
     IsSubgamePerfectOn (optStrategy : Strategy Player ℚ) sample :=
-  optStrategy_isSubgamePerfect.toSubgamePerfectOn sample
+  optStrategy_isSubgamePerfectOn sample
+
+/-- The global SPE predicate is equivalent to root-scoped SPE at every root. -/
+theorem sample_optStrategy_global_spe_iff_roots :
+    IsSubgamePerfect (optStrategy : Strategy Player ℚ) ↔
+      ∀ g : GameTree Player ℚ,
+        IsSubgamePerfectOn (optStrategy : Strategy Player ℚ) g :=
+  isSubgamePerfect_iff_forall_isSubgamePerfectOn
+
+/-- The global backward-induction SPE is Nash at the sample root. -/
+theorem sample_optStrategy_nash_at :
+    IsNashAt (optStrategy : Strategy Player ℚ) sample :=
+  optStrategy_isNashAt sample
+
+/-- The left child is Player A's proper subgame in the sample tree. -/
+theorem sample_left_subgame :
+    Subtree sampleLeftSubgame sample := by
+  unfold sample
+  change Subtree sampleLeftSubgame
+    (Node (1 : Player) sampleLeftSubgame
+      (List.cons (Leaf (zeroSumLeaf 3)) List.nil))
+  exact Subtree.head (1 : Player)
+    sampleLeftSubgame
+    (List.cons (Leaf (zeroSumLeaf 3)) List.nil)
+
+/-- The left child is a nontrivial subgame, not just a reflexive subtree. -/
+theorem sample_left_properSubgame :
+    ProperSubgame sampleLeftSubgame sample := by
+  unfold sample
+  change ProperSubgame sampleLeftSubgame
+    (Node (1 : Player) sampleLeftSubgame
+      (List.cons (Leaf (zeroSumLeaf 3)) List.nil))
+  exact ProperSubgame.head (1 : Player)
+    sampleLeftSubgame
+    (List.cons (Leaf (zeroSumLeaf 3)) List.nil)
+
+/-- Root-scoped SPE on the sample restricts to Player A's proper subgame. -/
+theorem sample_optStrategy_spe_on_left_subgame :
+    IsSubgamePerfectOn (optStrategy : Strategy Player ℚ) sampleLeftSubgame :=
+  optStrategy_isSubgamePerfectOn_properSubgame sample_left_properSubgame
+
+/-- Root-scoped SPE on the sample gives Nash equilibrium at Player A's
+    proper subgame. -/
+theorem sample_optStrategy_nash_at_left_subgame :
+    IsNashAt (optStrategy : Strategy Player ℚ) sampleLeftSubgame :=
+  optStrategy_isNashAt_properSubgame sample_left_properSubgame
+
+/-- The direct-child convenience theorem gives the same SPE restriction to
+    Player A's subgame. -/
+theorem sample_optStrategy_spe_on_head :
+    IsSubgamePerfectOn (optStrategy : Strategy Player ℚ) sampleLeftSubgame := by
+  simpa [sample, sampleLeftSubgame] using
+    (sample_optStrategy_spe_on.head
+      (m := (1 : Player))
+      (h := sampleLeftSubgame)
+      (t := List.cons (Leaf (zeroSumLeaf 3)) List.nil))
+
+/-- The direct-child convenience theorem also gives Nash equilibrium at
+    Player A's subgame. -/
+theorem sample_optStrategy_nash_at_head :
+    IsNashAt (optStrategy : Strategy Player ℚ) sampleLeftSubgame := by
+  simpa [sample, sampleLeftSubgame] using
+    (sample_optStrategy_spe_on.toNashAt_head
+      (m := (1 : Player))
+      (h := sampleLeftSubgame)
+      (t := List.cons (Leaf (zeroSumLeaf 3)) List.nil))
+
+/-- Kuhn's theorem gives one pure strategy that is subgame-perfect on every
+    subtree of the sample root. -/
+theorem sample_has_spe_on_every_subtree :
+    ∃ σ : Strategy Player ℚ,
+      ∀ s : GameTree Player ℚ, Subtree s sample → IsSubgamePerfectOn σ s :=
+  Kuhn_exists_SPE_on_subtrees sample
+
+/-- The same pure strategy can be viewed as Nash at every subtree of the sample
+    root. This is the pure finite-tree subtree-Nash consequence of SPE. -/
+theorem sample_has_nash_at_every_subtree :
+    ∃ σ : Strategy Player ℚ,
+      ∀ s : GameTree Player ℚ, Subtree s sample → IsNashAt σ s :=
+  Kuhn_exists_NE_on_subtrees sample
+
+/-- The recursive node characterization splits subgame perfection on `sample`
+    into root Nash, SPE on Player A's subgame, and SPE on the right leaf. -/
+theorem sample_optStrategy_spe_on_decomposes :
+    IsNashAt (optStrategy : Strategy Player ℚ) sample ∧
+      IsSubgamePerfectOn (optStrategy : Strategy Player ℚ) sampleLeftSubgame ∧
+        ∀ c ∈ List.cons (Leaf (zeroSumLeaf 3)) List.nil,
+          IsSubgamePerfectOn (optStrategy : Strategy Player ℚ) c := by
+  simpa [sample, sampleLeftSubgame] using
+    (isSubgamePerfectOn_Node_iff
+      (σ := (optStrategy : Strategy Player ℚ))
+      (m := (1 : Player))
+      (h := sampleLeftSubgame)
+      (t := List.cons (Leaf (zeroSumLeaf 3)) List.nil)).mp
+        sample_optStrategy_spe_on
+
+/-- The right terminal branch is automatically Nash for every strategy. -/
+theorem sample_right_leaf_nash_at (σ : Strategy Player ℚ) :
+    IsNashAt σ (Leaf (zeroSumLeaf 3)) :=
+  isNashAt_Leaf σ (zeroSumLeaf 3)
 
 /-- The extracted strategic-form game has a pure Nash equilibrium, and this is
     exactly the root-scoped Nash predicate on the original tree. -/

--- a/EconCSLib/Examples/UltimatumGame.lean
+++ b/EconCSLib/Examples/UltimatumGame.lean
@@ -1,0 +1,1004 @@
+/-
+Copyright (c) 2026 EconCSLib contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+
+import EconCSLib.GameTheory.ExtensiveGame.GameTreeStrategicForm
+import EconCSLib.GameTheory.ExtensiveGame.Strategy
+
+/-!
+# Examples.UltimatumGame
+
+Ultimatum-game examples for MSZ Chapter 7.
+
+The first section follows Exercise 7.5 directly: Allen asks for an integer
+amount between 0 and 100, Rick accepts or rejects, and the file records the
+extensive-form structure, pure strategy sets, and Nash payoff construction.
+
+The later section is a compact two-offer worked example in the `GameTree`
+framework.  It uses the existing finite-tree API for subtrees, Kuhn's theorem,
+root-scoped Nash equilibrium, subgame-perfect equilibrium, and strategic-form
+extraction.
+
+## References
+
+* [MSZ] Chapter 7, Exercise 7.5
+-/
+
+/-! ## MSZ Exercise 7.5: full 0..100 extensive-form specification
+
+This section follows the textbook exercise directly. Allen first asks for an
+integer amount between 0 and 100. Rick observes Allen's request and accepts or
+rejects. If Rick accepts, Allen receives the requested amount and Rick receives
+the remainder. If Rick rejects, both receive zero.
+
+The later `GameTree` section is a smaller two-offer worked example used to
+exercise the current finite-tree equilibrium API.
+-/
+
+namespace Examples.UltimatumGame.Full
+
+/-! ### Players, offers, responses, and states -/
+
+/-- The two textbook players. -/
+inductive Player
+  | Allen
+  | Rick
+  deriving DecidableEq, Repr
+
+/-- Allen's requested amount, represented as `Fin 101`, i.e. `{0, ..., 100}`. -/
+abbrev Offer := Fin 101
+
+/-- Rick's response after observing Allen's offer. -/
+inductive Response
+  | Accept
+  | Reject
+  deriving DecidableEq, Repr
+
+open Player Response
+
+/-- States of the full 0..100 ultimatum game. -/
+inductive State
+  | root
+  | rickDecision (x : Offer)
+  | accepted (x : Offer)
+  | rejected (x : Offer)
+  deriving DecidableEq, Repr
+
+open State
+
+/-- Available actions at each state.
+
+At the root, Allen chooses one of the 101 offers.  At a Rick decision node,
+Rick chooses accept or reject.  Terminal states have no actions. -/
+def action : State → Type
+  | root => Offer
+  | rickDecision _ => Response
+  | accepted _ => Empty
+  | rejected _ => Empty
+
+/-- Transition function for the full Exercise 7.5 game. -/
+def next : (s : State) → action s → State
+  | root, x => rickDecision x
+  | rickDecision x, Accept => accepted x
+  | rickDecision x, Reject => rejected x
+
+/-- Player assignment for the full Exercise 7.5 game. -/
+def mover : State → Option Player
+  | root => some Allen
+  | rickDecision _ => some Rick
+  | accepted _ => none
+  | rejected _ => none
+
+/-- Payoffs for the full Exercise 7.5 game.
+
+If Rick accepts offer `x`, Allen receives `x` and Rick receives `100 - x`.
+If Rick rejects, both receive zero.  Nonterminal payoffs are set to zero because
+only terminal payoffs matter. -/
+def payoff : State → Player → ℤ
+  | accepted x, Allen => x.val
+  | accepted x, Rick => 100 - x.val
+  | rejected _, _ => 0
+  | _, _ => 0
+
+/-- The full 0..100 extensive-form ultimatum game from MSZ Exercise 7.5. -/
+def game : ExtensiveGame Player ℤ where
+  State := State
+  Action := action
+  next := next
+  init := root
+  mover := mover
+  payoff := payoff
+
+/-! ### Basic verification -/
+
+example : game.mover root = some Allen := rfl
+
+example (x : Offer) : game.mover (rickDecision x) = some Rick := rfl
+
+example (x : Offer) : game.next root x = rickDecision x := rfl
+
+example (x : Offer) : game.next (rickDecision x) Accept = accepted x := rfl
+
+example (x : Offer) : game.next (rickDecision x) Reject = rejected x := rfl
+
+example (x : Offer) : game.payoff (accepted x) Allen = x.val := rfl
+
+example (x : Offer) : game.payoff (accepted x) Rick = 100 - x.val := rfl
+
+example (x : Offer) : game.payoff (rejected x) Allen = 0 := rfl
+
+example (x : Offer) : game.payoff (rejected x) Rick = 0 := rfl
+
+example (x : Offer) : IsEmpty (game.Action (accepted x)) := by
+  constructor
+  intro a
+  cases a
+
+example (x : Offer) : IsEmpty (game.Action (rejected x)) := by
+  constructor
+  intro a
+  cases a
+
+/-! ### Pure strategy sets -/
+
+/-- Allen's pure strategies are exactly the 101 offers. -/
+abbrev AllenStrategy := Offer
+
+/-- Rick's pure strategies specify accept/reject after each possible offer. -/
+abbrev RickStrategy := Offer → Response
+
+/-- Extract Allen's chosen offer from an extensive-game pure strategy. -/
+def allenStrategy (σ : game.Strategy Allen) : AllenStrategy :=
+  σ root rfl
+
+/-- Extract Rick's complete contingent response plan from an extensive-game
+    pure strategy. -/
+def rickStrategy (τ : game.Strategy Rick) : RickStrategy :=
+  fun x => τ (rickDecision x) rfl
+
+theorem allenStrategy_surjective (x : AllenStrategy) :
+    ∃ σ : game.Strategy Allen, allenStrategy σ = x := by
+  refine ⟨fun s hs => ?_, ?_⟩
+  · cases s with
+    | root => exact x
+    | rickDecision y => cases hs
+    | accepted y => cases hs
+    | rejected y => cases hs
+  · rfl
+
+theorem rickStrategy_surjective (r : RickStrategy) :
+    ∃ τ : game.Strategy Rick, rickStrategy τ = r := by
+  refine ⟨fun s hs => ?_, ?_⟩
+  · cases s with
+    | root => cases hs
+    | rickDecision x => exact r x
+    | accepted x => cases hs
+    | rejected x => cases hs
+  · rfl
+
+/-! ### Nash payoff construction -/
+
+/-- The terminal state induced by a fixed offer and Rick response. -/
+def responseState (x : Offer) : Response → State
+  | Accept => accepted x
+  | Reject => rejected x
+
+/-- A pure strategy profile for the full 0..100 ultimatum game. -/
+structure Profile where
+  allen : AllenStrategy
+  rick : RickStrategy
+
+namespace Profile
+
+/-- Extensionality for pure strategy profiles. -/
+theorem ext {σ τ : Profile} (hallen : σ.allen = τ.allen)
+    (hrick : σ.rick = τ.rick) : σ = τ := by
+  cases σ with
+  | mk a r =>
+      cases τ with
+      | mk a' r' =>
+          dsimp at hallen hrick
+          subst a'
+          subst r'
+          rfl
+
+/-- The terminal state induced by a pure strategy profile. -/
+def outcomeState (σ : Profile) : State :=
+  responseState σ.allen (σ.rick σ.allen)
+
+/-- The payoff induced by a pure strategy profile. -/
+def payoff (σ : Profile) (i : Player) : ℤ :=
+  Full.payoff σ.outcomeState i
+
+/-- Change Allen's offer, holding Rick's contingent plan fixed. -/
+def deviateAllen (σ : Profile) (x : AllenStrategy) : Profile :=
+  { σ with allen := x }
+
+/-- Change Rick's contingent response plan, holding Allen's offer fixed. -/
+def deviateRick (σ : Profile) (r : RickStrategy) : Profile :=
+  { σ with rick := r }
+
+end Profile
+
+/-- Pure Nash equilibrium for the full Exercise 7.5 strategic representation. -/
+def IsNashProfile (σ : Profile) : Prop :=
+  (∀ x : AllenStrategy, (σ.deviateAllen x).payoff Allen ≤ σ.payoff Allen) ∧
+    ∀ r : RickStrategy, (σ.deviateRick r).payoff Rick ≤ σ.payoff Rick
+
+theorem offer_val_nonneg (x : Offer) : (0 : ℤ) ≤ x.val := by
+  omega
+
+theorem offer_val_le_hundred (x : Offer) : (x.val : ℤ) ≤ 100 := by
+  have hx : x.val < 101 := x.isLt
+  omega
+
+/-- Rick accepts exactly offer `a` and rejects every other offer. -/
+def acceptsOnly (a : Offer) : RickStrategy :=
+  fun x => if x = a then Accept else Reject
+
+/-- The Nash profile supporting accepted split `(a, 100-a)`. -/
+def nashProfile (a : Offer) : Profile where
+  allen := a
+  rick := acceptsOnly a
+
+theorem nashProfile_payoff (a : Offer) :
+    (nashProfile a).payoff Allen = a.val ∧
+      (nashProfile a).payoff Rick = 100 - a.val := by
+  simp [nashProfile, acceptsOnly, Profile.payoff, Profile.outcomeState,
+    responseState, payoff]
+
+/-- Every split `(a, 100-a)` is a Nash-equilibrium payoff.
+
+The supporting profile has Allen ask for `a`, while Rick accepts exactly `a`
+and rejects all other offers. -/
+theorem nashProfile_isNash (a : Offer) :
+    IsNashProfile (nashProfile a) := by
+  constructor
+  · intro x
+    by_cases hx : x = a
+    · subst hx
+      simp [nashProfile, acceptsOnly, Profile.deviateAllen, Profile.payoff,
+        Profile.outcomeState, responseState, payoff]
+    · have ha_nonneg : (0 : ℤ) ≤ a.val := offer_val_nonneg a
+      simp [nashProfile, acceptsOnly, Profile.deviateAllen, Profile.payoff,
+        Profile.outcomeState, responseState, payoff, hx, ha_nonneg]
+  · intro r
+    by_cases hr : r a = Accept
+    · simp [nashProfile, acceptsOnly, Profile.deviateRick, Profile.payoff,
+        Profile.outcomeState, responseState, payoff, hr]
+    · have hrReject : r a = Reject := by
+        cases h : r a with
+        | Accept => exact False.elim (hr h)
+        | Reject => rfl
+      have ha_le : (a.val : ℤ) ≤ 100 := offer_val_le_hundred a
+      simp [nashProfile, acceptsOnly, Profile.deviateRick, Profile.payoff,
+        Profile.outcomeState, responseState, payoff, hrReject, ha_le]
+
+theorem nashProfile_payoff_set (a : Offer) :
+    IsNashProfile (nashProfile a) ∧
+      (nashProfile a).payoff Allen = a.val ∧
+        (nashProfile a).payoff Rick = 100 - a.val :=
+  ⟨nashProfile_isNash a, (nashProfile_payoff a).1, (nashProfile_payoff a).2⟩
+
+/-! ### Subgame response optimality -/
+
+/-- The offer in which Allen asks for all 100 dollars. -/
+def hundred : Offer := ⟨100, by omega⟩
+
+/-- The offer in which Allen asks for 99 dollars. -/
+def ninetyNine : Offer := ⟨99, by omega⟩
+
+theorem hundred_val : hundred.val = 100 := rfl
+
+theorem ninetyNine_val : ninetyNine.val = 99 := rfl
+
+theorem eq_hundred_of_val_eq (x : Offer) (h : (x.val : ℤ) = 100) :
+    x = hundred := by
+  apply Fin.ext
+  have hnat : x.val = 100 := by omega
+  simpa [hundred] using hnat
+
+theorem eq_ninetyNine_of_val_eq (x : Offer) (h : (x.val : ℤ) = 99) :
+    x = ninetyNine := by
+  apply Fin.ext
+  have hnat : x.val = 99 := by omega
+  simpa [ninetyNine] using hnat
+
+theorem ninetyNine_ne_hundred : ninetyNine ≠ hundred := by
+  intro h
+  have hval : ninetyNine.val = hundred.val := congrArg Fin.val h
+  have h99 : ninetyNine.val = 99 := rfl
+  have h100 : hundred.val = 100 := rfl
+  omega
+
+theorem offer_val_le_ninetyNine_of_ne_hundred (x : Offer)
+    (hx : x ≠ hundred) : (x.val : ℤ) ≤ 99 := by
+  have hxle : (x.val : ℤ) ≤ 100 := offer_val_le_hundred x
+  have hxne : (x.val : ℤ) ≠ 100 := by
+    intro hval
+    exact hx (eq_hundred_of_val_eq x hval)
+  omega
+
+/-- Rick's response is optimal in the one-decision subgame following offer `x`. -/
+def ResponseBestAt (x : Offer) (r : Response) : Prop :=
+  ∀ y : Response, Full.payoff (responseState x y) Rick ≤
+    Full.payoff (responseState x r) Rick
+
+/-- Rick is sequentially rational at every one-offer subgame. -/
+def RickSequentiallyRational (r : RickStrategy) : Prop :=
+  ∀ x : Offer, ResponseBestAt x (r x)
+
+/-- Accepting is always a weakly optimal response for Rick, because
+`100 - x ≥ 0` for every admissible offer. -/
+theorem responseBest_accept (x : Offer) : ResponseBestAt x Accept := by
+  intro y
+  cases y
+  · simp [responseState, payoff]
+  · have hx : (x.val : ℤ) ≤ 100 := offer_val_le_hundred x
+    simp [responseState, payoff]
+    omega
+
+/-- Rejecting is also weakly optimal after the offer `100`, where Rick receives
+zero whether he accepts or rejects. -/
+theorem responseBest_reject_hundred : ResponseBestAt hundred Reject := by
+  intro y
+  cases y
+  · change (100 : ℤ) - (hundred.val : ℤ) ≤ 0
+    have hval : hundred.val = 100 := rfl
+    omega
+  · rfl
+
+theorem responseBest_reject_iff (x : Offer) :
+    ResponseBestAt x Reject ↔ x = hundred := by
+  constructor
+  · intro h
+    have hAccept := h Accept
+    have hxle : (x.val : ℤ) ≤ 100 := offer_val_le_hundred x
+    have hval : (x.val : ℤ) = 100 := by
+      simp [responseState, payoff] at hAccept
+      omega
+    exact eq_hundred_of_val_eq x hval
+  · intro hx
+    subst x
+    exact responseBest_reject_hundred
+
+theorem rickSequentiallyRational_iff (r : RickStrategy) :
+    RickSequentiallyRational r ↔ ∀ x : Offer, r x = Accept ∨ x = hundred := by
+  constructor
+  · intro h x
+    cases hr : r x with
+    | Accept => exact Or.inl rfl
+    | Reject =>
+        have hbest : ResponseBestAt x Reject := by
+          simpa [hr] using h x
+        exact Or.inr ((responseBest_reject_iff x).mp hbest)
+  · intro h x
+    cases hr : r x with
+    | Accept =>
+        simpa [hr] using responseBest_accept x
+    | Reject =>
+        rcases h x with hacc | hx
+        · rw [hacc] at hr
+          cases hr
+        · subst x
+          simpa [hr] using responseBest_reject_hundred
+
+/-- Rick accepts every offer. -/
+def acceptsAll : RickStrategy :=
+  fun _ => Accept
+
+/-- Rick accepts every offer below 100 and rejects the offer 100. -/
+def acceptsBelowHundred : RickStrategy :=
+  fun x => if x = hundred then Reject else Accept
+
+theorem acceptsAll_sequentiallyRational :
+    RickSequentiallyRational acceptsAll := by
+  intro x
+  exact responseBest_accept x
+
+theorem acceptsBelowHundred_sequentiallyRational :
+    RickSequentiallyRational acceptsBelowHundred := by
+  intro x
+  by_cases hx : x = hundred
+  · subst x
+    simp [acceptsBelowHundred, responseBest_reject_hundred]
+  · simp [acceptsBelowHundred, hx, responseBest_accept]
+
+theorem rickSequentiallyRational_eq_acceptsAll_of_hundred_accept
+    {r : RickStrategy} (hR : RickSequentiallyRational r)
+    (h100 : r hundred = Accept) :
+    r = acceptsAll := by
+  funext x
+  by_cases hx : x = hundred
+  · subst x
+    simpa [acceptsAll] using h100
+  · have hx_or := (rickSequentiallyRational_iff r).mp hR x
+    rcases hx_or with hacc | hhundred
+    · simpa [acceptsAll] using hacc
+    · exact False.elim (hx hhundred)
+
+theorem rickSequentiallyRational_eq_acceptsBelowHundred_of_hundred_reject
+    {r : RickStrategy} (hR : RickSequentiallyRational r)
+    (h100 : r hundred = Reject) :
+    r = acceptsBelowHundred := by
+  funext x
+  by_cases hx : x = hundred
+  · subst x
+    simp [acceptsBelowHundred, h100]
+  · have hx_or := (rickSequentiallyRational_iff r).mp hR x
+    rcases hx_or with hacc | hhundred
+    · simp [acceptsBelowHundred, hx, hacc]
+    · exact False.elim (hx hhundred)
+
+/-! ### Subgame-perfect profiles -/
+
+/-- Allen's offer is optimal at the root against Rick's contingent plan. -/
+def AllenBestAgainst (x : AllenStrategy) (r : RickStrategy) : Prop :=
+  ∀ y : AllenStrategy, Full.payoff (responseState y (r y)) Allen ≤
+    Full.payoff (responseState x (r x)) Allen
+
+/-- Pure subgame perfection for this two-stage game: Allen is optimal at the
+root and Rick is optimal in every one-offer subgame. -/
+def IsSubgamePerfectProfile (σ : Profile) : Prop :=
+  AllenBestAgainst σ.allen σ.rick ∧ RickSequentiallyRational σ.rick
+
+theorem IsSubgamePerfectProfile.toNashProfile {σ : Profile}
+    (hσ : IsSubgamePerfectProfile σ) :
+    IsNashProfile σ := by
+  rcases hσ with ⟨hAllen, hRick⟩
+  constructor
+  · intro x
+    simpa [AllenBestAgainst, Profile.deviateAllen, Profile.payoff,
+      Profile.outcomeState] using hAllen x
+  · intro r
+    have hBest : ResponseBestAt σ.allen (σ.rick σ.allen) := hRick σ.allen
+    simpa [ResponseBestAt, Profile.deviateRick, Profile.payoff,
+      Profile.outcomeState] using hBest (r σ.allen)
+
+theorem allenBest_acceptsAll_hundred :
+    AllenBestAgainst hundred acceptsAll := by
+  intro y
+  have hy : y.val < 101 := y.isLt
+  simp [acceptsAll, responseState, payoff, hundred]
+  omega
+
+theorem allenBest_acceptsAll_iff (x : AllenStrategy) :
+    AllenBestAgainst x acceptsAll ↔ x = hundred := by
+  constructor
+  · intro h
+    have hHundred := h hundred
+    have hxle : (x.val : ℤ) ≤ 100 := offer_val_le_hundred x
+    have hge : (100 : ℤ) ≤ x.val := by
+      simp [acceptsAll, responseState, payoff, hundred] at hHundred
+      omega
+    have hval : (x.val : ℤ) = 100 := by omega
+    exact eq_hundred_of_val_eq x hval
+  · intro hx
+    subst x
+    exact allenBest_acceptsAll_hundred
+
+theorem allenBest_acceptsBelowHundred_ninetyNine :
+    AllenBestAgainst ninetyNine acceptsBelowHundred := by
+  intro y
+  by_cases hy : y = hundred
+  · subst y
+    have hle : (0 : ℤ) ≤ 99 := by omega
+    simp [acceptsBelowHundred, responseState, payoff, ninetyNine, hundred]
+  · have hle : (y.val : ℤ) ≤ 99 :=
+      offer_val_le_ninetyNine_of_ne_hundred y hy
+    simpa [acceptsBelowHundred, hy, ninetyNine_ne_hundred, responseState,
+      payoff, ninetyNine] using hle
+
+theorem allenBest_acceptsBelowHundred_iff (x : AllenStrategy) :
+    AllenBestAgainst x acceptsBelowHundred ↔ x = ninetyNine := by
+  constructor
+  · intro h
+    by_cases hx : x = hundred
+    · subst x
+      have hNinetyNine := h ninetyNine
+      simp [acceptsBelowHundred, responseState, payoff, ninetyNine, hundred]
+        at hNinetyNine
+    · have hNinetyNine := h ninetyNine
+      have hxle : (x.val : ℤ) ≤ 99 :=
+        offer_val_le_ninetyNine_of_ne_hundred x hx
+      have hge : (99 : ℤ) ≤ x.val := by
+        simpa [acceptsBelowHundred, hx, ninetyNine_ne_hundred, responseState,
+          payoff, ninetyNine] using hNinetyNine
+      have hval : (x.val : ℤ) = 99 := by omega
+      exact eq_ninetyNine_of_val_eq x hval
+  · intro hx
+    subst x
+    exact allenBest_acceptsBelowHundred_ninetyNine
+
+/-- The SPE where Rick accepts the offer 100, so Allen asks for 100. -/
+def acceptHundredProfile : Profile where
+  allen := hundred
+  rick := acceptsAll
+
+/-- The SPE where Rick rejects the offer 100, so Allen asks for 99. -/
+def rejectHundredProfile : Profile where
+  allen := ninetyNine
+  rick := acceptsBelowHundred
+
+theorem acceptHundredProfile_isSubgamePerfect :
+    IsSubgamePerfectProfile acceptHundredProfile :=
+  ⟨allenBest_acceptsAll_hundred, acceptsAll_sequentiallyRational⟩
+
+theorem rejectHundredProfile_isSubgamePerfect :
+    IsSubgamePerfectProfile rejectHundredProfile :=
+  ⟨allenBest_acceptsBelowHundred_ninetyNine,
+    acceptsBelowHundred_sequentiallyRational⟩
+
+/-- The full pure-strategy SPE characterization for the 0..100 ultimatum game. -/
+theorem isSubgamePerfectProfile_iff (σ : Profile) :
+    IsSubgamePerfectProfile σ ↔
+      σ = acceptHundredProfile ∨ σ = rejectHundredProfile := by
+  constructor
+  · intro hσ
+    rcases hσ with ⟨hAllen, hRick⟩
+    cases h100 : σ.rick hundred with
+    | Accept =>
+        have hr : σ.rick = acceptsAll :=
+          rickSequentiallyRational_eq_acceptsAll_of_hundred_accept hRick h100
+        have hAllen' : AllenBestAgainst σ.allen acceptsAll := by
+          simpa [hr] using hAllen
+        have hx : σ.allen = hundred := (allenBest_acceptsAll_iff σ.allen).mp hAllen'
+        exact Or.inl (Profile.ext hx hr)
+    | Reject =>
+        have hr : σ.rick = acceptsBelowHundred :=
+          rickSequentiallyRational_eq_acceptsBelowHundred_of_hundred_reject
+            hRick h100
+        have hAllen' : AllenBestAgainst σ.allen acceptsBelowHundred := by
+          simpa [hr] using hAllen
+        have hx : σ.allen = ninetyNine :=
+          (allenBest_acceptsBelowHundred_iff σ.allen).mp hAllen'
+        exact Or.inr (Profile.ext hx hr)
+  · rintro (rfl | rfl)
+    · exact acceptHundredProfile_isSubgamePerfect
+    · exact rejectHundredProfile_isSubgamePerfect
+
+theorem acceptHundredProfile_payoff :
+    acceptHundredProfile.payoff Allen = 100 ∧
+      acceptHundredProfile.payoff Rick = 0 := by
+  constructor
+  · change (hundred.val : ℤ) = 100
+    simp [hundred_val]
+  · change (100 : ℤ) - (hundred.val : ℤ) = 0
+    simp [hundred_val]
+
+theorem rejectHundredProfile_payoff :
+    rejectHundredProfile.payoff Allen = 99 ∧
+      rejectHundredProfile.payoff Rick = 1 := by
+  constructor
+  · change Full.payoff (responseState ninetyNine (acceptsBelowHundred ninetyNine))
+      Allen = 99
+    change (ninetyNine.val : ℤ) = 99
+    simp [ninetyNine_val]
+  · change Full.payoff (responseState ninetyNine (acceptsBelowHundred ninetyNine))
+      Rick = 1
+    change (100 : ℤ) - (ninetyNine.val : ℤ) = 1
+    simp [ninetyNine_val]
+
+end Examples.UltimatumGame.Full
+
+namespace Examples.UltimatumGame
+
+open GameTree
+
+/-! ### Players and terminal payoffs -/
+
+/-- The two players in the ultimatum game. -/
+inductive Player
+  | Proposer
+  | Responder
+  deriving DecidableEq, Repr
+
+open Player
+
+/-- Payoff vector for a terminal split. -/
+def payoff (proposer responder : ℤ) : Player → ℤ
+  | Proposer => proposer
+  | Responder => responder
+
+/-- Terminal tree for a payoff vector. -/
+def terminal (proposer responder : ℤ) : GameTree Player ℤ :=
+  Leaf (payoff proposer responder)
+
+/-- Rejection gives both players zero. -/
+def reject : GameTree Player ℤ :=
+  terminal 0 0
+
+/-- The low offer gives the proposer 2 and the responder 1 if accepted. -/
+def acceptLow : GameTree Player ℤ :=
+  terminal 2 1
+
+/-- The high offer gives the proposer 1 and the responder 2 if accepted. -/
+def acceptHigh : GameTree Player ℤ :=
+  terminal 1 2
+
+/-! ### Game tree -/
+
+/-- The responder's decision after the low offer.
+
+The head child is acceptance; the tail child is rejection. -/
+def lowOfferResponse : GameTree Player ℤ :=
+  Node Responder acceptLow (List.cons reject List.nil)
+
+/-- The responder's decision after the high offer.
+
+The head child is acceptance; the tail child is rejection. -/
+def highOfferResponse : GameTree Player ℤ :=
+  Node Responder acceptHigh (List.cons reject List.nil)
+
+/-- The full two-offer ultimatum game.
+
+The proposer chooses the low offer first or the high offer second. -/
+def ultimatumGame : GameTree Player ℤ :=
+  Node Proposer lowOfferResponse (List.cons highOfferResponse List.nil)
+
+/-! ### Basic payoff and tree checks -/
+
+example : payoff 2 1 Proposer = 2 := rfl
+
+example : payoff 2 1 Responder = 1 := rfl
+
+example : payoff 0 0 Proposer = 0 := rfl
+
+example : children lowOfferResponse = List.cons acceptLow (List.cons reject List.nil) := rfl
+
+example : children highOfferResponse = List.cons acceptHigh (List.cons reject List.nil) := rfl
+
+example : children ultimatumGame =
+    List.cons lowOfferResponse (List.cons highOfferResponse List.nil) := rfl
+
+/-! ### Backward-induction values -/
+
+/-- At the low-offer response node, backward induction accepts the low offer. -/
+theorem lowOfferResponse_value :
+    value lowOfferResponse = payoff 2 1 := by
+  have hchild :
+      ∃ c ∈ List.cons acceptLow (List.cons reject List.nil),
+        value lowOfferResponse = value c := by
+    simpa [lowOfferResponse] using
+      (value_Node_eq_some_child_value
+        (m := Responder)
+        (h := acceptLow)
+        (t := List.cons reject List.nil))
+  rcases hchild with ⟨c, hmem, hvalue⟩
+  rcases List.mem_cons.mp hmem with rfl | hmem_tail
+  · simpa [acceptLow, terminal] using hvalue
+  · have hc : c = reject := by
+      simpa using hmem_tail
+    subst c
+    have hge :
+        (value acceptLow) Responder ≤ (value lowOfferResponse) Responder := by
+      simpa [lowOfferResponse] using
+        (value_Node_ge Responder acceptLow (List.cons reject List.nil)
+          acceptLow (by simp))
+    have hbad : (1 : ℤ) ≤ 0 := by
+      simp [acceptLow, reject, terminal, payoff, hvalue] at hge
+    exact False.elim ((by decide : ¬ ((1 : ℤ) ≤ 0)) hbad)
+
+/-- At the high-offer response node, backward induction accepts the high offer. -/
+theorem highOfferResponse_value :
+    value highOfferResponse = payoff 1 2 := by
+  have hchild :
+      ∃ c ∈ List.cons acceptHigh (List.cons reject List.nil),
+        value highOfferResponse = value c := by
+    simpa [highOfferResponse] using
+      (value_Node_eq_some_child_value
+        (m := Responder)
+        (h := acceptHigh)
+        (t := List.cons reject List.nil))
+  rcases hchild with ⟨c, hmem, hvalue⟩
+  rcases List.mem_cons.mp hmem with rfl | hmem_tail
+  · simpa [acceptHigh, terminal] using hvalue
+  · have hc : c = reject := by
+      simpa using hmem_tail
+    subst c
+    have hge :
+        (value acceptHigh) Responder ≤ (value highOfferResponse) Responder := by
+      simpa [highOfferResponse] using
+        (value_Node_ge Responder acceptHigh (List.cons reject List.nil)
+          acceptHigh (by simp))
+    have hbad : (2 : ℤ) ≤ 0 := by
+      simp [acceptHigh, reject, terminal, payoff, hvalue] at hge
+    exact False.elim ((by decide : ¬ ((2 : ℤ) ≤ 0)) hbad)
+
+/-- At the root, backward induction selects the low offer because it gives the
+    proposer payoff `2`, while the high offer gives proposer payoff `1`. -/
+theorem ultimatumGame_value :
+    value ultimatumGame = payoff 2 1 := by
+  have hchild :
+      ∃ c ∈ List.cons lowOfferResponse (List.cons highOfferResponse List.nil),
+        value ultimatumGame = value c := by
+    simpa [ultimatumGame] using
+      (value_Node_eq_some_child_value
+        (m := Proposer)
+        (h := lowOfferResponse)
+        (t := List.cons highOfferResponse List.nil))
+  rcases hchild with ⟨c, hmem, hvalue⟩
+  rcases List.mem_cons.mp hmem with rfl | hmem_tail
+  · simpa [lowOfferResponse_value] using hvalue
+  · have hc : c = highOfferResponse := by
+      simpa using hmem_tail
+    subst c
+    have hge :
+        (value lowOfferResponse) Proposer ≤ (value ultimatumGame) Proposer := by
+      simpa [ultimatumGame] using
+        (value_Node_ge Proposer lowOfferResponse
+          (List.cons highOfferResponse List.nil) lowOfferResponse (by simp))
+    have hbad : (2 : ℤ) ≤ 1 := by
+      simp [lowOfferResponse_value, highOfferResponse_value, payoff, hvalue] at hge
+    exact False.elim ((by decide : ¬ ((2 : ℤ) ≤ 1)) hbad)
+
+/-- The canonical backward-induction strategy reaches the low accepted split. -/
+theorem ultimatum_optStrategy_outcome :
+    outcome (optStrategy : Strategy Player ℤ) ultimatumGame = payoff 2 1 := by
+  rw [outcome_optStrategy_eq_value]
+  exact ultimatumGame_value
+
+/-- Under the canonical backward-induction strategy, the proposer gets `2`. -/
+theorem ultimatum_optStrategy_proposer_payoff :
+    outcome (optStrategy : Strategy Player ℤ) ultimatumGame Proposer = 2 := by
+  rw [ultimatum_optStrategy_outcome]
+  rfl
+
+/-- Under the canonical backward-induction strategy, the responder gets `1`. -/
+theorem ultimatum_optStrategy_responder_payoff :
+    outcome (optStrategy : Strategy Player ℤ) ultimatumGame Responder = 1 := by
+  rw [ultimatum_optStrategy_outcome]
+  rfl
+
+/-! ### Subgames and terminal subgames -/
+
+/-- The low-offer response node is the head subgame of the full game. -/
+theorem lowOfferResponse_subtree :
+    Subtree lowOfferResponse ultimatumGame := by
+  unfold ultimatumGame
+  exact Subtree.head Proposer lowOfferResponse
+    (List.cons highOfferResponse List.nil)
+
+/-- The low-offer response node is a proper subgame of the full game. -/
+theorem lowOfferResponse_properSubgame :
+    ProperSubgame lowOfferResponse ultimatumGame := by
+  unfold ultimatumGame
+  exact ProperSubgame.head Proposer lowOfferResponse
+    (List.cons highOfferResponse List.nil)
+
+/-- The high-offer response node is the tail subgame of the full game. -/
+theorem highOfferResponse_subtree :
+    Subtree highOfferResponse ultimatumGame := by
+  unfold ultimatumGame
+  exact Subtree.tail_mem Proposer lowOfferResponse
+    (List.cons highOfferResponse List.nil) (by simp)
+
+/-- The high-offer response node is a proper subgame of the full game. -/
+theorem highOfferResponse_properSubgame :
+    ProperSubgame highOfferResponse ultimatumGame := by
+  unfold ultimatumGame
+  exact ProperSubgame.tail_mem Proposer lowOfferResponse
+    (List.cons highOfferResponse List.nil) (by simp)
+
+/-- The accepted low offer is the head terminal subgame of the low-offer
+    response node. -/
+theorem acceptLow_subtree_lowOfferResponse :
+    Subtree acceptLow lowOfferResponse := by
+  unfold lowOfferResponse
+  exact Subtree.head Responder acceptLow (List.cons reject List.nil)
+
+/-- Rejection is the tail terminal subgame of the low-offer response node. -/
+theorem reject_subtree_lowOfferResponse :
+    Subtree reject lowOfferResponse := by
+  unfold lowOfferResponse
+  exact Subtree.tail_mem Responder acceptLow (List.cons reject List.nil) (by simp)
+
+/-- The accepted high offer is the head terminal subgame of the high-offer
+    response node. -/
+theorem acceptHigh_subtree_highOfferResponse :
+    Subtree acceptHigh highOfferResponse := by
+  unfold highOfferResponse
+  exact Subtree.head Responder acceptHigh (List.cons reject List.nil)
+
+/-- Rejection is also the tail terminal subgame of the high-offer response node. -/
+theorem reject_subtree_highOfferResponse :
+    Subtree reject highOfferResponse := by
+  unfold highOfferResponse
+  exact Subtree.tail_mem Responder acceptHigh (List.cons reject List.nil) (by simp)
+
+/-- The accepted low offer is a terminal subtree of the full game. -/
+theorem acceptLow_subtree_ultimatumGame :
+    Subtree acceptLow ultimatumGame :=
+  Subtree.trans acceptLow_subtree_lowOfferResponse lowOfferResponse_subtree
+
+/-- The accepted low offer is a proper terminal subgame of the full game. -/
+theorem acceptLow_properSubgame_ultimatumGame :
+    ProperSubgame acceptLow ultimatumGame :=
+  Subtree.trans_properSubgame acceptLow_subtree_lowOfferResponse
+    lowOfferResponse_properSubgame
+
+/-- The accepted high offer is a terminal subtree of the full game. -/
+theorem acceptHigh_subtree_ultimatumGame :
+    Subtree acceptHigh ultimatumGame :=
+  Subtree.trans acceptHigh_subtree_highOfferResponse highOfferResponse_subtree
+
+/-- The accepted high offer is a proper terminal subgame of the full game. -/
+theorem acceptHigh_properSubgame_ultimatumGame :
+    ProperSubgame acceptHigh ultimatumGame :=
+  Subtree.trans_properSubgame acceptHigh_subtree_highOfferResponse
+    highOfferResponse_properSubgame
+
+/-- Rejection is a terminal subtree of the full game through the low-offer
+    response node. -/
+theorem reject_subtree_ultimatumGame :
+    Subtree reject ultimatumGame :=
+  Subtree.trans reject_subtree_lowOfferResponse lowOfferResponse_subtree
+
+/-- Rejection is a proper terminal subgame of the full game through the
+    low-offer response node. -/
+theorem reject_properSubgame_ultimatumGame :
+    ProperSubgame reject ultimatumGame :=
+  Subtree.trans_properSubgame reject_subtree_lowOfferResponse
+    lowOfferResponse_properSubgame
+
+/-- Terminal accepted-low subgames have no proper subgames. -/
+theorem acceptLow_hasOnlyRootSubgames :
+    HasOnlyRootSubgames acceptLow := by
+  unfold acceptLow terminal
+  exact hasOnlyRootSubgames_Leaf (payoff 2 1)
+
+/-- Terminal rejection subgames have no proper subgames. -/
+theorem reject_hasOnlyRootSubgames :
+    HasOnlyRootSubgames reject := by
+  unfold reject terminal
+  exact hasOnlyRootSubgames_Leaf (payoff 0 0)
+
+/-- On the accepted-low terminal subgame, root Nash already implies
+    root-scoped subgame perfection.  This instantiates the no-proper-subgames
+    theorem on a concrete terminal branch. -/
+theorem acceptLow_nash_to_spe_on {σ : Strategy Player ℤ}
+    (hnash : IsNashAt σ acceptLow) :
+    IsSubgamePerfectOn σ acceptLow :=
+  hnash.toSubgamePerfectOn_of_hasOnlyRootSubgames acceptLow_hasOnlyRootSubgames
+
+/-- On the rejection terminal subgame, root Nash already implies root-scoped
+    subgame perfection. -/
+theorem reject_nash_to_spe_on {σ : Strategy Player ℤ}
+    (hnash : IsNashAt σ reject) :
+    IsSubgamePerfectOn σ reject :=
+  hnash.toSubgamePerfectOn_of_hasOnlyRootSubgames reject_hasOnlyRootSubgames
+
+/-! ### Equilibrium facts from the `GameTree` library -/
+
+/-- The ultimatum game has a pure subgame-perfect equilibrium by Kuhn's theorem. -/
+theorem ultimatum_has_spe :
+    ∃ σ : Strategy Player ℤ, IsSubgamePerfect σ :=
+  Kuhn_exists_SPE
+
+/-- The ultimatum game has a root-scoped subgame-perfect equilibrium. -/
+theorem ultimatum_has_spe_on :
+    ∃ σ : Strategy Player ℤ, IsSubgamePerfectOn σ ultimatumGame :=
+  Kuhn_exists_SPE_on ultimatumGame
+
+/-- The ultimatum game has a pure Nash equilibrium at the root. -/
+theorem ultimatum_has_nash_at :
+    ∃ σ : Strategy Player ℤ, IsNashAt σ ultimatumGame :=
+  Kuhn_exists_NE ultimatumGame
+
+/-- One pure strategy is subgame-perfect on every subtree of the ultimatum game. -/
+theorem ultimatum_has_spe_on_every_subtree :
+    ∃ σ : Strategy Player ℤ,
+      ∀ s : GameTree Player ℤ,
+        Subtree s ultimatumGame → IsSubgamePerfectOn σ s :=
+  Kuhn_exists_SPE_on_subtrees ultimatumGame
+
+/-- The same pure strategy is Nash at every subtree of the ultimatum game. -/
+theorem ultimatum_has_nash_at_every_subtree :
+    ∃ σ : Strategy Player ℤ,
+      ∀ s : GameTree Player ℤ, Subtree s ultimatumGame → IsNashAt σ s :=
+  Kuhn_exists_NE_on_subtrees ultimatumGame
+
+/-- The canonical backward-induction strategy is subgame-perfect on the root. -/
+theorem ultimatum_optStrategy_spe_on :
+    IsSubgamePerfectOn (optStrategy : Strategy Player ℤ) ultimatumGame :=
+  optStrategy_isSubgamePerfectOn ultimatumGame
+
+/-- The canonical backward-induction strategy is Nash at the root. -/
+theorem ultimatum_optStrategy_nash_at :
+    IsNashAt (optStrategy : Strategy Player ℤ) ultimatumGame :=
+  optStrategy_isNashAt ultimatumGame
+
+/-- Root-scoped SPE restricts to the low-offer response subgame. -/
+theorem ultimatum_optStrategy_spe_on_lowOfferResponse :
+    IsSubgamePerfectOn (optStrategy : Strategy Player ℤ) lowOfferResponse :=
+  optStrategy_isSubgamePerfectOn_properSubgame lowOfferResponse_properSubgame
+
+/-- Root-scoped SPE restricts to the high-offer response subgame. -/
+theorem ultimatum_optStrategy_spe_on_highOfferResponse :
+    IsSubgamePerfectOn (optStrategy : Strategy Player ℤ) highOfferResponse :=
+  optStrategy_isSubgamePerfectOn_properSubgame highOfferResponse_properSubgame
+
+/-- The low-offer response subgame is Nash under the backward-induction
+    strategy. -/
+theorem ultimatum_optStrategy_nash_at_lowOfferResponse :
+    IsNashAt (optStrategy : Strategy Player ℤ) lowOfferResponse :=
+  optStrategy_isNashAt_properSubgame lowOfferResponse_properSubgame
+
+/-- The high-offer response subgame is Nash under the backward-induction
+    strategy. -/
+theorem ultimatum_optStrategy_nash_at_highOfferResponse :
+    IsNashAt (optStrategy : Strategy Player ℤ) highOfferResponse :=
+  optStrategy_isNashAt_properSubgame highOfferResponse_properSubgame
+
+/-- The backward-induction strategy is Nash at every subtree of the root. -/
+theorem ultimatum_optStrategy_nash_at_every_subtree :
+    ∀ s : GameTree Player ℤ, Subtree s ultimatumGame →
+      IsNashAt (optStrategy : Strategy Player ℤ) s :=
+  ultimatum_optStrategy_spe_on.forall_subtree_isNashAt
+
+/-- Subgame perfection on the full ultimatum game decomposes into root Nash,
+    SPE on the low-offer response subgame, and SPE on the high-offer response
+    subgame. -/
+theorem ultimatum_optStrategy_spe_on_decomposes :
+    IsNashAt (optStrategy : Strategy Player ℤ) ultimatumGame ∧
+      IsSubgamePerfectOn (optStrategy : Strategy Player ℤ) lowOfferResponse ∧
+        ∀ c ∈ List.cons highOfferResponse List.nil,
+          IsSubgamePerfectOn (optStrategy : Strategy Player ℤ) c := by
+  change IsNashAt (optStrategy : Strategy Player ℤ)
+      (Node Proposer lowOfferResponse (List.cons highOfferResponse List.nil)) ∧
+    IsSubgamePerfectOn (optStrategy : Strategy Player ℤ) lowOfferResponse ∧
+      ∀ c ∈ List.cons highOfferResponse List.nil,
+        IsSubgamePerfectOn (optStrategy : Strategy Player ℤ) c
+  exact
+    (isSubgamePerfectOn_Node_iff
+      (σ := (optStrategy : Strategy Player ℤ))
+      (m := Proposer)
+      (h := lowOfferResponse)
+      (t := List.cons highOfferResponse List.nil)).mp
+        (by simpa [ultimatumGame] using ultimatum_optStrategy_spe_on)
+
+/-- Subgame perfection on the low-offer response node decomposes into Nash at
+    that response node and SPE on both terminal branches. -/
+theorem lowOfferResponse_optStrategy_spe_on_decomposes :
+    IsNashAt (optStrategy : Strategy Player ℤ) lowOfferResponse ∧
+      IsSubgamePerfectOn (optStrategy : Strategy Player ℤ) acceptLow ∧
+        ∀ c ∈ List.cons reject List.nil,
+          IsSubgamePerfectOn (optStrategy : Strategy Player ℤ) c := by
+  change IsNashAt (optStrategy : Strategy Player ℤ)
+      (Node Responder acceptLow (List.cons reject List.nil)) ∧
+    IsSubgamePerfectOn (optStrategy : Strategy Player ℤ) acceptLow ∧
+      ∀ c ∈ List.cons reject List.nil,
+        IsSubgamePerfectOn (optStrategy : Strategy Player ℤ) c
+  exact
+    (isSubgamePerfectOn_Node_iff
+      (σ := (optStrategy : Strategy Player ℤ))
+      (m := Responder)
+      (h := acceptLow)
+      (t := List.cons reject List.nil)).mp
+        (by simpa [lowOfferResponse] using ultimatum_optStrategy_spe_on_lowOfferResponse)
+
+/-! ### Strategic-form extraction -/
+
+/-- The extracted strategic-form game for the ultimatum tree. -/
+noncomputable def ultimatumStrategicGame : StrategicGame Player ℤ :=
+  toStrategicGame ultimatumGame
+
+/-- The extracted strategic-form game has a pure Nash equilibrium, and the
+    extracted profile corresponds to root-scoped Nash equilibrium in the
+    original tree. -/
+theorem ultimatum_strategic_form_has_nash :
+    ∃ σ : ultimatumStrategicGame.Profile,
+      _root_.IsNashEquilibrium ultimatumStrategicGame σ ∧
+        IsNashAt (profileStrategy σ) ultimatumGame := by
+  have hprofile :
+      profileStrategy (fun _ => optStrategy : ultimatumStrategicGame.Profile) =
+        (optStrategy : Strategy Player ℤ) := rfl
+  refine ⟨fun _ => optStrategy, ?_, ?_⟩
+  · exact (toStrategicGame_nash_iff_isNashAt ultimatumGame
+      (fun _ => optStrategy)).mpr
+      (by simpa [ultimatumStrategicGame, hprofile] using
+        optStrategy_isSubgamePerfect.toNE ultimatumGame)
+  · simpa [hprofile] using optStrategy_isSubgamePerfect.toNE ultimatumGame
+
+end Examples.UltimatumGame

--- a/EconCSLib/GameTheory/ExtensiveGame/FiniteArenaExtraction.lean
+++ b/EconCSLib/GameTheory/ExtensiveGame/FiniteArenaExtraction.lean
@@ -127,7 +127,7 @@ theorem ExtractsGameTree.node_head_reachable {s : G.State} {i : N}
 
 /-- On any extracted tree, root-scoped subgame perfection implies root Nash
 equilibrium through the ordinary `GameTree` equilibrium API. -/
-theorem ExtractsGameTree.spe_on_to_nash_at [TotalPreorder U]
+theorem ExtractsGameTree.spe_on_to_nash_at [TotalPreorder U] [DecidableLE U]
     {s : G.State} {tree : GameTree N U}
     (_h : ExtractsGameTree G s tree) {σ : GameTree.Strategy N U}
     (hspe : GameTree.IsSubgamePerfectOn σ tree) :

--- a/EconCSLib/GameTheory/ExtensiveGame/GameTree.lean
+++ b/EconCSLib/GameTheory/ExtensiveGame/GameTree.lean
@@ -7,7 +7,7 @@ import EconCSLib.Foundation.Preference
 import Mathlib.Data.List.Basic
 
 /-!
-# EconCSLib.GameTheory.ExtensiveGame.GameTree
+# ExtensiveGame.GameTree
 
 Finite extensive-form games of **perfect information, without chance**,
 encoded as a generic inductive type.
@@ -15,12 +15,12 @@ encoded as a generic inductive type.
 ## Design
 
 ```
-inductive GameTree (N U : Type*)
-  | Leaf (payoff : N → U)
-  | Node (mover : N) (head : GameTree N U) (tail : List (GameTree N U))
+inductive GameTree (ι U : Type*)
+  | Leaf (payoff : ι → U)
+  | Node (mover : ι) (head : GameTree ι U) (tail : List (GameTree ι U))
 ```
 
-* **N** — the player set (need not be finite or decidable).
+* **ι** — the player set (need not be finite or decidable).
 * **U** — the payoff type (will acquire `[TotalPreorder U]` at theorem sites,
   not in the type definition — Bourbaki discipline).
 * **Finite** via inductive structure.
@@ -34,63 +34,66 @@ inductive GameTree (N U : Type*)
 * `GameTree` — the inductive type itself
 * `GameTree.size` — structural size (well-founded recursion helper)
 * `GameTree.children` — the full child list `head :: tail` at a `Node`
+* `GameTree.Subtree` — the reflexive subtree relation
+* `GameTree.ProperSubgame` — a subtree strictly below a fixed root
+* `GameTree.HasOnlyRootSubgames` — the root is the only subtree
 * `GameTree.mapChildren` — apply a function to every child of a `Node`
 
 ## References
 
-* [MSZ, Ch. 3] Maschler, Solan, Zamir, *Game Theory* (Cambridge, 2013) —
-  extensive games (backward induction; Kuhn 1953)
+* [MSZ] Maschler, Solan, Zamir, *Game Theory*, Chapter 3 (extensive games),
+  Theorem 3.13 (Kuhn)
 -/
 
 /-- A finite extensive-form game of perfect information, without chance.
 
-    * `Leaf payoff` — a terminal state with a payoff vector `N → U`.
+    * `Leaf payoff` — a terminal state with a payoff vector `ι → U`.
     * `Node mover head tail` — a decision node owned by `mover`,
       with non-empty children `head :: tail`.
 
     Finiteness is built into the inductive type; non-emptiness of
     children is built into the `Node` constructor via `head + tail`. -/
-inductive GameTree (N : Type*) (U : Type*) : Type _
-  | Leaf (payoff : N → U) : GameTree N U
-  | Node (mover : N) (head : GameTree N U) (tail : List (GameTree N U)) :
-      GameTree N U
+inductive GameTree (ι : Type*) (U : Type*) : Type _
+  | Leaf (payoff : ι → U) : GameTree ι U
+  | Node (mover : ι) (head : GameTree ι U) (tail : List (GameTree ι U)) :
+      GameTree ι U
 
 namespace GameTree
 
-variable {N U : Type*}
+variable {ι U : Type*}
 
 /-- The full child list at a `Node`, as a guaranteed non-empty list. -/
 @[simp]
-def children : GameTree N U → List (GameTree N U)
+def children : GameTree ι U → List (GameTree ι U)
   | Leaf _ => []
   | Node _ h t => h :: t
 
 /-- Children of a `Node` are never empty. -/
-theorem children_node_ne_nil (m : N) (h : GameTree N U) (t : List (GameTree N U)) :
+theorem children_node_ne_nil (m : ι) (h : GameTree ι U) (t : List (GameTree ι U)) :
     children (Node m h t) ≠ [] := by
   simp [children]
 
 /-- Structural size, used for well-founded recursion. -/
-def size : GameTree N U → ℕ
+def size : GameTree ι U → ℕ
   | Leaf _ => 1
   | Node _ h t => 1 + h.size + (t.map size).sum
 
 /-- Size is always positive. -/
-theorem size_pos (g : GameTree N U) : 0 < g.size := by
+theorem size_pos (g : GameTree ι U) : 0 < g.size := by
   cases g with
   | Leaf _ => simp [size]
   | Node _ _ _ => simp [size]; omega
 
 /-- The head of a `Node`'s children is structurally smaller. -/
-theorem size_head_lt (m : N) (h : GameTree N U) (t : List (GameTree N U)) :
+theorem size_head_lt (m : ι) (h : GameTree ι U) (t : List (GameTree ι U)) :
     h.size < (Node m h t).size := by
   simp [size]
   have : 0 ≤ (t.map size).sum := Nat.zero_le _
   omega
 
 /-- Any tail child is structurally smaller. -/
-theorem size_mem_tail_lt (m : N) (h : GameTree N U) (t : List (GameTree N U))
-    {c : GameTree N U} (hmem : c ∈ t) :
+theorem size_mem_tail_lt (m : ι) (h : GameTree ι U) (t : List (GameTree ι U))
+    {c : GameTree ι U} (hmem : c ∈ t) :
     c.size < (Node m h t).size := by
   simp only [size]
   have hsum : c.size ≤ (t.map size).sum := by
@@ -106,8 +109,8 @@ theorem size_mem_tail_lt (m : N) (h : GameTree N U) (t : List (GameTree N U))
   omega
 
 /-- Any child (head or in tail) is structurally smaller than the node. -/
-theorem size_mem_children_lt (m : N) (h : GameTree N U) (t : List (GameTree N U))
-    {c : GameTree N U} (hmem : c ∈ children (Node m h t)) :
+theorem size_mem_children_lt (m : ι) (h : GameTree ι U) (t : List (GameTree ι U))
+    {c : GameTree ι U} (hmem : c ∈ children (Node m h t)) :
     c.size < (Node m h t).size := by
   simp [children, List.mem_cons] at hmem
   rcases hmem with rfl | hmem'
@@ -121,42 +124,249 @@ as the head / a tail element, recursively). Useful for stating subgame-perfect
 properties quantified over all reachable subgames. -/
 
 /-- `Subtree s g` — `s` occurs as a subtree of `g`. -/
-inductive Subtree : GameTree N U → GameTree N U → Prop
-  | refl (g : GameTree N U) : Subtree g g
-  | inHead (s : GameTree N U) (m : N) (h : GameTree N U) (t : List (GameTree N U))
+inductive Subtree : GameTree ι U → GameTree ι U → Prop
+  | refl (g : GameTree ι U) : Subtree g g
+  | inHead (s : GameTree ι U) (m : ι) (h : GameTree ι U) (t : List (GameTree ι U))
       (hs : Subtree s h) : Subtree s (Node m h t)
-  | inTail (s : GameTree N U) (m : N) (h : GameTree N U) (t : List (GameTree N U))
-      {c : GameTree N U} (hmem : c ∈ t) (hs : Subtree s c) :
+  | inTail (s : GameTree ι U) (m : ι) (h : GameTree ι U) (t : List (GameTree ι U))
+      {c : GameTree ι U} (hmem : c ∈ t) (hs : Subtree s c) :
       Subtree s (Node m h t)
 
 /-- Every tree is a subtree of itself. -/
-theorem Subtree.self (g : GameTree N U) : Subtree g g := Subtree.refl g
+theorem Subtree.self (g : GameTree ι U) : Subtree g g := Subtree.refl g
 
 /-- The head of a `Node` is a subtree of the node. -/
-theorem Subtree.head (m : N) (h : GameTree N U) (t : List (GameTree N U)) :
+theorem Subtree.head (m : ι) (h : GameTree ι U) (t : List (GameTree ι U)) :
     Subtree h (Node m h t) :=
   Subtree.inHead h m h t (Subtree.refl h)
 
 /-- Any tail member of a `Node` is a subtree of the node. -/
-theorem Subtree.tail_mem (m : N) (h : GameTree N U) (t : List (GameTree N U))
-    {c : GameTree N U} (hmem : c ∈ t) : Subtree c (Node m h t) :=
+theorem Subtree.tail_mem (m : ι) (h : GameTree ι U) (t : List (GameTree ι U))
+    {c : GameTree ι U} (hmem : c ∈ t) : Subtree c (Node m h t) :=
   Subtree.inTail c m h t hmem (Subtree.refl c)
 
 /-- Any child (head or tail) is a subtree. -/
-theorem Subtree.child_mem (m : N) (h : GameTree N U) (t : List (GameTree N U))
-    {c : GameTree N U} (hmem : c ∈ h :: t) : Subtree c (Node m h t) := by
+theorem Subtree.child_mem (m : ι) (h : GameTree ι U) (t : List (GameTree ι U))
+    {c : GameTree ι U} (hmem : c ∈ h :: t) : Subtree c (Node m h t) := by
   rcases List.mem_cons.mp hmem with rfl | hmem'
   · exact Subtree.head m c t
   · exact Subtree.tail_mem m h t hmem'
 
+/-- Any child in the public `children` list is a subtree. -/
+theorem Subtree.child (m : ι) (h : GameTree ι U) (t : List (GameTree ι U))
+    {c : GameTree ι U} (hmem : c ∈ children (Node m h t)) :
+    Subtree c (Node m h t) :=
+  Subtree.child_mem m h t (by simpa [children] using hmem)
+
 /-- The subtree relation is transitive. In game-theoretic terms, a subgame of
     a subgame is also a subgame of the original game. -/
-theorem Subtree.trans {r s g : GameTree N U} (hrs : Subtree r s) (hsg : Subtree s g) :
+theorem Subtree.trans {r s g : GameTree ι U} (hrs : Subtree r s) (hsg : Subtree s g) :
     Subtree r g := by
   induction hsg with
   | refl => exact hrs
   | inHead m h t _ ih => exact Subtree.inHead r m h t ih
   | inTail m h t hmem _ ih => exact Subtree.inTail r m h t hmem ih
+
+/-- A subtree is no larger than the tree containing it. -/
+theorem Subtree.size_le {s g : GameTree ι U} (hsub : Subtree s g) :
+    s.size ≤ g.size := by
+  induction hsub with
+  | refl => exact Nat.le_refl _
+  | inHead m h t _ ih =>
+      exact Nat.le_trans ih (Nat.le_of_lt (size_head_lt m h t))
+  | inTail m h t hmem _ ih =>
+      exact Nat.le_trans ih (Nat.le_of_lt (size_mem_tail_lt m h t hmem))
+
+/-! ### Proper subgames -/
+
+/-- A proper subgame is a subtree strictly below the chosen root. -/
+def ProperSubgame (s g : GameTree ι U) : Prop :=
+  Subtree s g ∧ s ≠ g
+
+/-- A proper subgame is, in particular, a subtree. -/
+theorem ProperSubgame.toSubtree {s g : GameTree ι U} (hproper : ProperSubgame s g) :
+    Subtree s g :=
+  hproper.1
+
+/-- A proper subgame is not the whole root tree. -/
+theorem ProperSubgame.ne {s g : GameTree ι U} (hproper : ProperSubgame s g) :
+    s ≠ g :=
+  hproper.2
+
+/-- Every subtree is either the root itself or a proper subgame. -/
+theorem Subtree.eq_or_properSubgame {s g : GameTree ι U} (hsub : Subtree s g) :
+    s = g ∨ ProperSubgame s g := by
+  by_cases hroot : s = g
+  · exact Or.inl hroot
+  · exact Or.inr ⟨hsub, hroot⟩
+
+/-- Subtree membership splits into the root case and the proper-subgame case. -/
+theorem subtree_iff_eq_or_properSubgame {s g : GameTree ι U} :
+    Subtree s g ↔ s = g ∨ ProperSubgame s g := by
+  constructor
+  · intro hsub
+    exact hsub.eq_or_properSubgame
+  · intro hcases
+    rcases hcases with hroot | hproper
+    · rw [hroot]
+      exact Subtree.self g
+    · exact hproper.toSubtree
+
+/-- No tree is a proper subgame of itself. -/
+theorem not_properSubgame_self (g : GameTree ι U) :
+    ¬ ProperSubgame g g := by
+  intro hproper
+  exact hproper.ne rfl
+
+/-- Proper subgames are structurally smaller than their root. -/
+theorem ProperSubgame.size_lt {s g : GameTree ι U} (hproper : ProperSubgame s g) :
+    s.size < g.size := by
+  rcases hproper with ⟨hsub, hne⟩
+  induction hsub with
+  | refl =>
+      exact False.elim (hne rfl)
+  | inHead m h t hs _ih =>
+      exact Nat.lt_of_le_of_lt hs.size_le (size_head_lt m h t)
+  | inTail m h t hmem hs _ih =>
+      exact Nat.lt_of_le_of_lt hs.size_le (size_mem_tail_lt m h t hmem)
+
+/-- A proper subgame of a subtree is a proper subgame of the larger root. -/
+theorem ProperSubgame.trans_subtree {r s g : GameTree ι U}
+    (hr : ProperSubgame r s) (hs : Subtree s g) :
+    ProperSubgame r g := by
+  refine ⟨Subtree.trans hr.toSubtree hs, ?_⟩
+  intro hrg
+  have hsize : r.size < s.size := hr.size_lt
+  have hle : s.size ≤ g.size := hs.size_le
+  subst hrg
+  exact Nat.lt_irrefl r.size (Nat.lt_of_lt_of_le hsize hle)
+
+/-- The proper-subgame relation is transitive. -/
+theorem ProperSubgame.trans {r s g : GameTree ι U}
+    (hr : ProperSubgame r s) (hs : ProperSubgame s g) :
+    ProperSubgame r g :=
+  hr.trans_subtree hs.toSubtree
+
+/-- A subtree of a proper subgame is a proper subgame of the larger root. -/
+theorem Subtree.trans_properSubgame {r s g : GameTree ι U}
+    (hr : Subtree r s) (hs : ProperSubgame s g) :
+    ProperSubgame r g := by
+  refine ⟨Subtree.trans hr hs.toSubtree, ?_⟩
+  intro hrg
+  have hle : r.size ≤ s.size := hr.size_le
+  have hsize : s.size < g.size := hs.size_lt
+  subst hrg
+  exact Nat.lt_irrefl r.size (Nat.lt_of_le_of_lt hle hsize)
+
+/-- The head child of a node is a proper subgame of that node. -/
+theorem ProperSubgame.head (m : ι) (h : GameTree ι U) (t : List (GameTree ι U)) :
+    ProperSubgame h (Node m h t) := by
+  refine ⟨Subtree.head m h t, ?_⟩
+  intro h_eq
+  have h_lt : h.size < (Node m h t).size := size_head_lt m h t
+  have h_size : (Node m h t).size = h.size := (congrArg size h_eq).symm
+  simp [h_size] at h_lt
+
+/-- Every tail child of a node is a proper subgame of that node. -/
+theorem ProperSubgame.tail_mem (m : ι) (h : GameTree ι U) (t : List (GameTree ι U))
+    {c : GameTree ι U} (hmem : c ∈ t) :
+    ProperSubgame c (Node m h t) := by
+  refine ⟨Subtree.tail_mem m h t hmem, ?_⟩
+  intro h_eq
+  have h_lt : c.size < (Node m h t).size := size_mem_tail_lt m h t hmem
+  have h_size : (Node m h t).size = c.size := (congrArg size h_eq).symm
+  simp [h_size] at h_lt
+
+/-- Every direct child of a node is a proper subgame of that node. -/
+theorem ProperSubgame.child_mem (m : ι) (h : GameTree ι U) (t : List (GameTree ι U))
+    {c : GameTree ι U} (hmem : c ∈ h :: t) :
+    ProperSubgame c (Node m h t) := by
+  rcases List.mem_cons.mp hmem with rfl | hmem'
+  · exact ProperSubgame.head m c t
+  · exact ProperSubgame.tail_mem m h t hmem'
+
+/-- Every child in the public `children` list is a proper subgame of the node. -/
+theorem ProperSubgame.child (m : ι) (h : GameTree ι U) (t : List (GameTree ι U))
+    {c : GameTree ι U} (hmem : c ∈ children (Node m h t)) :
+    ProperSubgame c (Node m h t) :=
+  ProperSubgame.child_mem m h t (by simpa [children] using hmem)
+
+/-- The proper subgames of a nonterminal node are exactly the subtrees of its
+    direct children. -/
+theorem properSubgame_Node_iff_exists_child_subtree
+    {s : GameTree ι U} {m : ι} {h : GameTree ι U} {t : List (GameTree ι U)} :
+    ProperSubgame s (Node m h t) ↔
+      ∃ c : GameTree ι U, c ∈ children (Node m h t) ∧ Subtree s c := by
+  constructor
+  · intro hproper
+    cases hproper.toSubtree with
+    | refl =>
+        exact False.elim (hproper.ne rfl)
+    | inHead m h t hs =>
+        exact ⟨h, by simp [children], hs⟩
+    | inTail m h t hmem hs =>
+        exact ⟨_, by simp [children, hmem], hs⟩
+  · rintro ⟨c, hmem, hs⟩
+    exact hs.trans_properSubgame (ProperSubgame.child m h t hmem)
+
+/-- The head/tail form of `properSubgame_Node_iff_exists_child_subtree`. -/
+theorem properSubgame_Node_iff_subtree_head_or_tail
+    {s : GameTree ι U} {m : ι} {h : GameTree ι U} {t : List (GameTree ι U)} :
+    ProperSubgame s (Node m h t) ↔
+      Subtree s h ∨ ∃ c : GameTree ι U, c ∈ t ∧ Subtree s c := by
+  rw [properSubgame_Node_iff_exists_child_subtree]
+  constructor
+  · rintro ⟨c, hmem, hs⟩
+    rcases List.mem_cons.mp (by simpa [children] using hmem) with rfl | hmem'
+    · exact Or.inl hs
+    · exact Or.inr ⟨c, hmem', hs⟩
+  · rintro (hs | ⟨c, hmem, hs⟩)
+    · exact ⟨h, by simp [children], hs⟩
+    · exact ⟨c, by simp [children, hmem], hs⟩
+
+/-- A fixed `GameTree` has no proper subgames when every subtree is the root
+    itself. This is the pure finite-tree analogue of having no nontrivial
+    subgames. -/
+def HasOnlyRootSubgames (g : GameTree ι U) : Prop :=
+  ∀ s : GameTree ι U, Subtree s g → s = g
+
+/-- Having only the root subgame is equivalent to having no proper subgames. -/
+theorem hasOnlyRootSubgames_iff_no_properSubgame (g : GameTree ι U) :
+    HasOnlyRootSubgames g ↔ ¬ ∃ s : GameTree ι U, ProperSubgame s g := by
+  constructor
+  · intro hroot hproper
+    rcases hproper with ⟨s, hsub, hne⟩
+    exact hne (hroot s hsub)
+  · intro hno s hsub
+    by_contra hne
+    exact hno ⟨s, hsub, hne⟩
+
+/-- A terminal leaf has no proper subgames. -/
+theorem hasOnlyRootSubgames_Leaf (p : ι → U) :
+    HasOnlyRootSubgames (Leaf p : GameTree ι U) := by
+  intro s hsub
+  cases hsub
+  rfl
+
+/-- Every nonterminal node has a proper subgame. -/
+theorem not_hasOnlyRootSubgames_Node (m : ι) (h : GameTree ι U)
+    (t : List (GameTree ι U)) :
+    ¬ HasOnlyRootSubgames (Node m h t) := by
+  intro hroot
+  have hproper : ProperSubgame h (Node m h t) := ProperSubgame.head m h t
+  exact hproper.ne (hroot h hproper.toSubtree)
+
+/-- A tree has only its root as a subgame if and only if it is terminal. -/
+theorem hasOnlyRootSubgames_iff_exists_leaf (g : GameTree ι U) :
+    HasOnlyRootSubgames g ↔ ∃ p : ι → U, g = Leaf p := by
+  constructor
+  · intro hroot
+    cases g with
+    | Leaf p => exact ⟨p, rfl⟩
+    | Node m h t =>
+        exact False.elim (not_hasOnlyRootSubgames_Node m h t hroot)
+  · rintro ⟨p, rfl⟩
+    exact hasOnlyRootSubgames_Leaf p
 
 /-! ### Strong induction on size
 
@@ -168,13 +378,13 @@ precisely what backward-induction proofs need. -/
 /-- **Strong induction**: to prove `motive g`, it suffices to handle `Leaf`
     and, for each `Node`, to prove the motive given the motive for every
     child (head or tail). -/
-theorem strong_induction {motive : GameTree N U → Prop}
+theorem strong_induction {motive : GameTree ι U → Prop}
     (base : ∀ p, motive (Leaf p))
-    (step : ∀ (m : N) (h : GameTree N U) (t : List (GameTree N U)),
+    (step : ∀ (m : ι) (h : GameTree ι U) (t : List (GameTree ι U)),
               (∀ c ∈ h :: t, motive c) → motive (Node m h t))
-    (g : GameTree N U) : motive g := by
+    (g : GameTree ι U) : motive g := by
   -- Well-founded recursion on `size`.
-  suffices h : ∀ (n : ℕ) (g : GameTree N U), g.size ≤ n → motive g from
+  suffices h : ∀ (n : ℕ) (g : GameTree ι U), g.size ≤ n → motive g from
     h g.size g (Nat.le_refl _)
   intro n
   induction n with

--- a/EconCSLib/GameTheory/ExtensiveGame/GameTreeNE.lean
+++ b/EconCSLib/GameTheory/ExtensiveGame/GameTreeNE.lean
@@ -6,7 +6,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import EconCSLib.GameTheory.ExtensiveGame.GameTreeSPE
 
 /-!
-# EconCSLib.GameTheory.ExtensiveGame.GameTreeNE
+# ExtensiveGame.GameTreeNE
 
 Nash equilibrium on `GameTree`, a weaker concept than subgame-perfect equilibrium.
 
@@ -20,29 +20,86 @@ not vice-versa — this is the classical distinction [MSZ §7.1].
   root-game outcome.
 * `GameTree.IsNashAt` — root-scoped alias for `IsNashEquilibrium`.
 * `GameTree.IsSubgamePerfectOn` — root-scoped subgame-perfect predicate.
+* `GameTree.ProperSubgame` — a subtree strictly below a fixed root.
 * `GameTree.HasOnlyRootSubgames` — every subgame of a fixed tree is the root.
 
 ## Main results
 
 * `IsSubgamePerfect.toNE` — SPE implies NE (as a corollary of Kuhn).
+* `IsSubgamePerfect.toNashAt` — the same implication with the root-scoped name.
+* `IsSubgamePerfect.of_forall_isNashAt` — build global SPE from Nash
+  equilibrium at every root.
+* `isSubgamePerfect_iff_forall_isNashAt` — global SPE is Nash equilibrium at
+  every root.
 * `IsSubgamePerfect.toSubgamePerfectOn` — global SPE implies root-scoped SPE.
+* `IsSubgamePerfect.of_forall_isSubgamePerfectOn` — build global SPE from
+  root-scoped SPE at every root.
+* `isSubgamePerfect_iff_forall_isSubgamePerfectOn` — global SPE is equivalent
+  to root-scoped SPE at every root.
 * `isSubgamePerfectOn_iff_forall_subtree_isNashAt` — subgame perfection on a
   root is exactly Nash equilibrium at every subtree.
+* `IsNashAt.toSubgamePerfectOn_of_forall_subtree_isNashAt` — build
+  root-scoped SPE from Nash equilibrium at every subtree.
+* `isNashAt_Leaf` / `isSubgamePerfectOn_Leaf` — leaves are automatically
+  Nash and subgame-perfect for every strategy.
+* `IsSubgamePerfectOn.of_subtree` — root-scoped SPE restricts to every subtree.
+* `IsSubgamePerfectOn.of_forall_subtree_isSubgamePerfectOn` — build
+  root-scoped SPE from root-scoped SPE on every subtree.
+* `isSubgamePerfectOn_iff_forall_subtree_isSubgamePerfectOn` — root-scoped SPE
+  is equivalent to root-scoped SPE on every subtree.
+* `IsSubgamePerfectOn.toNashAt_of_subtree` — root-scoped SPE gives Nash
+  equilibrium at every subtree.
+* `IsSubgamePerfectOn.of_properSubgame` / `toNashAt_of_properSubgame` —
+  proper-subgame versions of the restriction facts.
+* `IsSubgamePerfectOn.toNashAt_and_forall_properSubgame_isNashAt` /
+  `toNashAt_and_forall_properSubgame_isSubgamePerfectOn` — bundled
+  root/proper-subgame consequences.
+* `IsNashAt.toSubgamePerfectOn_of_forall_properSubgame_isNashAt` — build
+  root-scoped SPE from root Nash plus Nash equilibrium at every proper subgame.
+* `isSubgamePerfectOn_iff_isNashAt_and_forall_properSubgame_isNashAt` —
+  root-scoped SPE as root Nash plus Nash equilibrium at every proper subgame.
+* `isSubgamePerfectOn_iff_isNashAt_and_forall_properSubgame_isSubgamePerfectOn` —
+  root-scoped SPE as root Nash plus root-scoped SPE on every proper subgame.
+* `IsSubgamePerfectOn.forall_subtree_isSubgamePerfectOn` /
+  `forall_subtree_isNashAt` — bundled subtree consequences.
+* `IsSubgamePerfectOn.head` / `tail_mem` / `child_mem` — convenience
+  restrictions to direct children of a node.
+* `IsSubgamePerfectOn.child` / `toNashAt_child` — the same restrictions through
+  the public `children` list API.
+* `isSubgamePerfectOn_Node_iff` — recursive decomposition into root Nash and
+  root-scoped SPE on each direct child.
+* `IsSubgamePerfectOn.toNashAt_and_head_tail` — bundled node decomposition into
+  root Nash plus head/tail SPE.
+* `IsNashAt.toSubgamePerfectOn_Node` — build root-scoped SPE at a node from
+  root Nash plus root-scoped SPE on each direct child.
+* `isSubgamePerfectOn_Node_iff_children` — the same recursive decomposition
+  through `children`.
 * `IsNashAt.toSubgamePerfectOn_of_hasOnlyRootSubgames` — if a tree has no
   proper subgames, every root Nash equilibrium is subgame-perfect on that tree
   (MSZ Theorem 7.4, pure finite-tree form).
+* `isSubgamePerfectOn_iff_isNashAt_of_no_properSubgame` — the proper-subgame
+  formulation of the no-nontrivial-subgames case.
+* `optStrategy_isSubgamePerfectOn` / `optStrategy_isNashAt` — the canonical
+  backward-induction strategy is root-scoped SPE, hence Nash, at every root.
+* `Kuhn_exists_SPE_on_subtrees` / `Kuhn_exists_NE_on_subtrees` — one pure
+  strategy witnesses subgame perfection, respectively Nash equilibrium, on
+  every subtree of a fixed finite root.
+* `Kuhn_exists_SPE_on_subtree` / `Kuhn_exists_NE_on_subtree` — fixed-subtree
+  existence wrappers for applying Kuhn's theorem to a named subgame.
+* `Kuhn_exists_NE_and_SPE_on_properSubgames` — one pure strategy is root Nash
+  and subgame-perfect on every proper subgame of a fixed finite root.
 -/
 
 namespace GameTree
 
-variable {N U : Type*} [TotalPreorder U]
+variable {ι U : Type*} [TotalPreorder U]
 
 /-- **Nash equilibrium**: no single player can improve their outcome at the
     root game by unilateral deviation.
 
     Weaker than `IsSubgamePerfect`, which demands optimality at every subtree. -/
-def IsNashEquilibrium (σ : Strategy N U) (g : GameTree N U) : Prop :=
-  ∀ (i : N) (σ' : Strategy N U),
+def IsNashEquilibrium (σ : Strategy ι U) (g : GameTree ι U) : Prop :=
+  ∀ (i : ι) (σ' : Strategy ι U),
     IVariant i σ σ' → outcome σ' g i ≤ outcome σ g i
 
 /-- Root-scoped Nash equilibrium predicate for a fixed `GameTree` root.
@@ -50,54 +107,577 @@ def IsNashEquilibrium (σ : Strategy N U) (g : GameTree N U) : Prop :=
 This is definitionally the existing `IsNashEquilibrium`, with the requested
 root-first API name for users who want to state equilibrium at a particular
 subgame rather than quantify over every subtree. -/
-abbrev IsNashAt (σ : Strategy N U) (g : GameTree N U) : Prop :=
+abbrev IsNashAt (σ : Strategy ι U) (g : GameTree ι U) : Prop :=
   IsNashEquilibrium σ g
 
 /-- Root-scoped subgame perfection on the subtrees of a fixed root.
 
-`IsSubgamePerfect σ` is global over every `GameTree N U`.  This predicate
+`IsSubgamePerfect σ` is global over every `GameTree ι U`.  This predicate
 restricts the same no-profitable-deviation condition to subgames that occur
 inside the chosen root `g`. -/
-def IsSubgamePerfectOn (σ : Strategy N U) (g : GameTree N U) : Prop :=
-  ∀ (s : GameTree N U), Subtree s g →
-    ∀ (i : N) (σ' : Strategy N U),
+def IsSubgamePerfectOn (σ : Strategy ι U) (g : GameTree ι U) : Prop :=
+  ∀ (s : GameTree ι U), Subtree s g →
+    ∀ (i : ι) (σ' : Strategy ι U),
       IVariant i σ σ' → outcome σ' s i ≤ outcome σ s i
-
-/-- A fixed `GameTree` has no proper subgames when every subtree is the root
-    itself. This is the pure finite-tree analogue of having no nontrivial
-    subgames. -/
-def HasOnlyRootSubgames (g : GameTree N U) : Prop :=
-  ∀ s : GameTree N U, Subtree s g → s = g
 
 /-- Root-scoped subgame perfection is equivalent to Nash equilibrium at every
     subtree of the root. This is the pure finite-tree form of MSZ Definition 7.2. -/
 theorem isSubgamePerfectOn_iff_forall_subtree_isNashAt
-    {σ : Strategy N U} {g : GameTree N U} :
-    IsSubgamePerfectOn σ g ↔ ∀ s : GameTree N U, Subtree s g → IsNashAt σ s :=
+    {σ : Strategy ι U} {g : GameTree ι U} :
+    IsSubgamePerfectOn σ g ↔ ∀ s : GameTree ι U, Subtree s g → IsNashAt σ s :=
   Iff.rfl
+
+/-- Nash equilibrium at every subtree of a root gives root-scoped subgame
+    perfection on that root. This is the constructor form of
+    `isSubgamePerfectOn_iff_forall_subtree_isNashAt`. -/
+theorem IsNashAt.toSubgamePerfectOn_of_forall_subtree_isNashAt
+    {σ : Strategy ι U} {g : GameTree ι U}
+    (hsubtrees : ∀ s : GameTree ι U, Subtree s g → IsNashAt σ s) :
+    IsSubgamePerfectOn σ g :=
+  hsubtrees
+
+/-- Every strategy is Nash at a terminal leaf: no player has a decision left
+    that could change the terminal payoff. -/
+theorem isNashAt_Leaf (σ : Strategy ι U) (p : ι → U) :
+    IsNashAt σ (Leaf p) := by
+  intro i σ' _hiv
+  simp
+
+/-- Every strategy is root-scoped subgame-perfect on a terminal leaf. -/
+theorem isSubgamePerfectOn_Leaf (σ : Strategy ι U) (p : ι → U) :
+    IsSubgamePerfectOn σ (Leaf p) := by
+  intro s hsub
+  cases hsub
+  exact isNashAt_Leaf σ p
+
+/-- On a terminal leaf, root-scoped subgame perfection is equivalent to root
+    Nash equilibrium. The forward implication holds for every root; the reverse
+    direction uses that a leaf has no proper subtrees. -/
+theorem isSubgamePerfectOn_Leaf_iff {σ : Strategy ι U} {p : ι → U} :
+    IsSubgamePerfectOn σ (Leaf p) ↔ IsNashAt σ (Leaf p) := by
+  constructor
+  · intro hspe
+    exact hspe (Leaf p) (Subtree.self (Leaf p))
+  · intro _hnash
+    exact isSubgamePerfectOn_Leaf σ p
+
+/-- Every terminal leaf has a root-scoped Nash equilibrium. -/
+theorem exists_isNashAt_Leaf (p : ι → U) :
+    ∃ σ : Strategy ι U, IsNashAt σ (Leaf p) := by
+  exact ⟨optStrategy, isNashAt_Leaf optStrategy p⟩
+
+/-- Every terminal leaf has a root-scoped subgame-perfect equilibrium. -/
+theorem exists_isSubgamePerfectOn_Leaf (p : ι → U) :
+    ∃ σ : Strategy ι U, IsSubgamePerfectOn σ (Leaf p) := by
+  exact ⟨optStrategy, isSubgamePerfectOn_Leaf optStrategy p⟩
+
+/-- On a terminal leaf, existence of root-scoped subgame perfection is
+    equivalent to existence of root Nash equilibrium. -/
+theorem exists_isSubgamePerfectOn_Leaf_iff_exists_isNashAt (p : ι → U) :
+    (∃ σ : Strategy ι U, IsSubgamePerfectOn σ (Leaf p)) ↔
+      ∃ σ : Strategy ι U, IsNashAt σ (Leaf p) := by
+  constructor
+  · rintro ⟨σ, hspe⟩
+    exact ⟨σ, isSubgamePerfectOn_Leaf_iff.mp hspe⟩
+  · rintro ⟨σ, _hnash⟩
+    exact ⟨σ, isSubgamePerfectOn_Leaf σ p⟩
 
 /-- **SPE ⇒ NE**: every subgame-perfect equilibrium is a Nash equilibrium
     (at any fixed root game). -/
-theorem IsSubgamePerfect.toNE {σ : Strategy N U} (hspe : IsSubgamePerfect σ)
-    (g : GameTree N U) : IsNashEquilibrium σ g :=
+theorem IsSubgamePerfect.toNE {σ : Strategy ι U} (hspe : IsSubgamePerfect σ)
+    (g : GameTree ι U) : IsNashEquilibrium σ g :=
   fun i σ' hiv => hspe g i σ' hiv
 
+/-- **SPE ⇒ root-scoped Nash** at any fixed root game. -/
+theorem IsSubgamePerfect.toNashAt {σ : Strategy ι U} (hspe : IsSubgamePerfect σ)
+    (g : GameTree ι U) : IsNashAt σ g :=
+  hspe.toNE g
+
+/-- Nash equilibrium at every root gives global subgame perfection. -/
+theorem IsSubgamePerfect.of_forall_isNashAt {σ : Strategy ι U}
+    (hnash : ∀ g : GameTree ι U, IsNashAt σ g) :
+    IsSubgamePerfect σ :=
+  hnash
+
+/-- Global subgame perfection is equivalent to Nash equilibrium at every root. -/
+theorem isSubgamePerfect_iff_forall_isNashAt {σ : Strategy ι U} :
+    IsSubgamePerfect σ ↔ ∀ g : GameTree ι U, IsNashAt σ g := by
+  constructor
+  · intro hspe g
+    exact hspe.toNashAt g
+  · intro hnash
+    exact IsSubgamePerfect.of_forall_isNashAt hnash
+
 /-- A global subgame-perfect equilibrium is subgame-perfect on every fixed root. -/
-theorem IsSubgamePerfect.toSubgamePerfectOn {σ : Strategy N U}
-    (hspe : IsSubgamePerfect σ) (g : GameTree N U) :
+theorem IsSubgamePerfect.toSubgamePerfectOn {σ : Strategy ι U}
+    (hspe : IsSubgamePerfect σ) (g : GameTree ι U) :
     IsSubgamePerfectOn σ g :=
   fun s _ i σ' hiv => hspe s i σ' hiv
 
+/-- Root-scoped subgame perfection at every root gives global subgame
+    perfection. -/
+theorem IsSubgamePerfect.of_forall_isSubgamePerfectOn {σ : Strategy ι U}
+    (hroots : ∀ g : GameTree ι U, IsSubgamePerfectOn σ g) :
+    IsSubgamePerfect σ := by
+  intro g i σ' hiv
+  exact hroots g g (Subtree.self g) i σ' hiv
+
+/-- Global subgame perfection is equivalent to root-scoped subgame perfection
+    at every possible root. -/
+theorem isSubgamePerfect_iff_forall_isSubgamePerfectOn {σ : Strategy ι U} :
+    IsSubgamePerfect σ ↔ ∀ g : GameTree ι U, IsSubgamePerfectOn σ g := by
+  constructor
+  · intro hspe g
+    exact hspe.toSubgamePerfectOn g
+  · intro hroots g i σ' hiv
+    exact IsSubgamePerfect.of_forall_isSubgamePerfectOn hroots g i σ' hiv
+
+/-- Existence of one strategy that is Nash at every root is equivalent to
+    existence of a global subgame-perfect strategy. -/
+theorem exists_forall_isNashAt_iff_exists_isSubgamePerfect :
+    (∃ σ : Strategy ι U, ∀ g : GameTree ι U, IsNashAt σ g) ↔
+      ∃ σ : Strategy ι U, IsSubgamePerfect σ := by
+  constructor
+  · rintro ⟨σ, hnash⟩
+    exact ⟨σ, IsSubgamePerfect.of_forall_isNashAt hnash⟩
+  · rintro ⟨σ, hspe⟩
+    exact ⟨σ, fun g => hspe.toNashAt g⟩
+
+/-- Existence of one strategy that is root-scoped subgame-perfect at every root
+    is equivalent to existence of a global subgame-perfect strategy. -/
+theorem exists_forall_isSubgamePerfectOn_iff_exists_isSubgamePerfect :
+    (∃ σ : Strategy ι U, ∀ g : GameTree ι U, IsSubgamePerfectOn σ g) ↔
+      ∃ σ : Strategy ι U, IsSubgamePerfect σ := by
+  constructor
+  · rintro ⟨σ, hroots⟩
+    exact ⟨σ, IsSubgamePerfect.of_forall_isSubgamePerfectOn hroots⟩
+  · rintro ⟨σ, hspe⟩
+    exact ⟨σ, fun g => hspe.toSubgamePerfectOn g⟩
+
 /-- Root-scoped subgame perfection implies Nash equilibrium at the same root. -/
-theorem IsSubgamePerfectOn.toNashAt {σ : Strategy N U} {g : GameTree N U}
+theorem IsSubgamePerfectOn.toNashAt {σ : Strategy ι U} {g : GameTree ι U}
     (hspe : IsSubgamePerfectOn σ g) : IsNashAt σ g :=
   fun i σ' hiv => hspe g (Subtree.self g) i σ' hiv
+
+/-- Root-scoped subgame perfection restricts to every subtree of the root.
+    This is the subgame-perfect side of the pure finite-tree form of
+    MSZ Theorem 7.5. -/
+theorem IsSubgamePerfectOn.of_subtree {σ : Strategy ι U} {s g : GameTree ι U}
+    (hspe : IsSubgamePerfectOn σ g) (hsub : Subtree s g) :
+    IsSubgamePerfectOn σ s := by
+  intro r hrs i σ' hiv
+  exact hspe r (Subtree.trans hrs hsub) i σ' hiv
+
+/-- If a strategy is root-scoped subgame-perfect on every subtree of a root,
+    then it is root-scoped subgame-perfect on that root. -/
+theorem IsSubgamePerfectOn.of_forall_subtree_isSubgamePerfectOn
+    {σ : Strategy ι U} {g : GameTree ι U}
+    (hsubtrees :
+      ∀ s : GameTree ι U, Subtree s g → IsSubgamePerfectOn σ s) :
+    IsSubgamePerfectOn σ g :=
+  hsubtrees g (Subtree.self g)
+
+/-- Root-scoped subgame perfection on a root is equivalent to root-scoped
+    subgame perfection on every subtree of that root. -/
+theorem isSubgamePerfectOn_iff_forall_subtree_isSubgamePerfectOn
+    {σ : Strategy ι U} {g : GameTree ι U} :
+    IsSubgamePerfectOn σ g ↔
+      ∀ s : GameTree ι U, Subtree s g → IsSubgamePerfectOn σ s := by
+  constructor
+  · intro hspe s hsub
+    exact hspe.of_subtree hsub
+  · intro hsubtrees
+    exact IsSubgamePerfectOn.of_forall_subtree_isSubgamePerfectOn hsubtrees
+
+/-- Root-scoped subgame perfection gives Nash equilibrium at every subtree.
+    This is the Nash-equilibrium side of the pure finite-tree form of
+    MSZ Theorem 7.5. -/
+theorem IsSubgamePerfectOn.toNashAt_of_subtree
+    {σ : Strategy ι U} {s g : GameTree ι U}
+    (hspe : IsSubgamePerfectOn σ g) (hsub : Subtree s g) :
+    IsNashAt σ s :=
+  (hspe.of_subtree hsub).toNashAt
+
+/-- Root-scoped subgame perfection restricts to every proper subgame of the
+    root. -/
+theorem IsSubgamePerfectOn.of_properSubgame
+    {σ : Strategy ι U} {s g : GameTree ι U}
+    (hspe : IsSubgamePerfectOn σ g) (hproper : ProperSubgame s g) :
+    IsSubgamePerfectOn σ s :=
+  hspe.of_subtree hproper.toSubtree
+
+/-- Root-scoped subgame perfection gives Nash equilibrium at every proper
+    subgame. -/
+theorem IsSubgamePerfectOn.toNashAt_of_properSubgame
+    {σ : Strategy ι U} {s g : GameTree ι U}
+    (hspe : IsSubgamePerfectOn σ g) (hproper : ProperSubgame s g) :
+    IsNashAt σ s :=
+  hspe.toNashAt_of_subtree hproper.toSubtree
+
+/-- A root-scoped subgame-perfect strategy is root-scoped subgame-perfect on
+    every subtree of the root. -/
+theorem IsSubgamePerfectOn.forall_subtree_isSubgamePerfectOn
+    {σ : Strategy ι U} {g : GameTree ι U}
+    (hspe : IsSubgamePerfectOn σ g) :
+    ∀ s : GameTree ι U, Subtree s g → IsSubgamePerfectOn σ s :=
+  fun _ hsub => hspe.of_subtree hsub
+
+/-- A root-scoped subgame-perfect strategy is Nash at every subtree of the root. -/
+theorem IsSubgamePerfectOn.forall_subtree_isNashAt
+    {σ : Strategy ι U} {g : GameTree ι U}
+    (hspe : IsSubgamePerfectOn σ g) :
+    ∀ s : GameTree ι U, Subtree s g → IsNashAt σ s :=
+  fun _ hsub => hspe.toNashAt_of_subtree hsub
+
+/-- Root-scoped subgame perfection gives root Nash equilibrium together with
+    Nash equilibrium at every subtree of the root. -/
+theorem IsSubgamePerfectOn.toNashAt_and_forall_subtree_isNashAt
+    {σ : Strategy ι U} {g : GameTree ι U}
+    (hspe : IsSubgamePerfectOn σ g) :
+    IsNashAt σ g ∧
+      ∀ s : GameTree ι U, Subtree s g → IsNashAt σ s :=
+  ⟨hspe.toNashAt, hspe.forall_subtree_isNashAt⟩
+
+/-- A root-scoped subgame-perfect strategy is root-scoped subgame-perfect on
+    every proper subgame of the root. -/
+theorem IsSubgamePerfectOn.forall_properSubgame_isSubgamePerfectOn
+    {σ : Strategy ι U} {g : GameTree ι U}
+    (hspe : IsSubgamePerfectOn σ g) :
+    ∀ s : GameTree ι U, ProperSubgame s g → IsSubgamePerfectOn σ s :=
+  fun _ hproper => hspe.of_properSubgame hproper
+
+/-- Root-scoped subgame perfection gives root Nash equilibrium together with
+    root-scoped subgame perfection on every subtree of the root. -/
+theorem IsSubgamePerfectOn.toNashAt_and_forall_subtree_isSubgamePerfectOn
+    {σ : Strategy ι U} {g : GameTree ι U}
+    (hspe : IsSubgamePerfectOn σ g) :
+    IsNashAt σ g ∧
+      ∀ s : GameTree ι U, Subtree s g → IsSubgamePerfectOn σ s :=
+  ⟨hspe.toNashAt, hspe.forall_subtree_isSubgamePerfectOn⟩
+
+/-- A root-scoped subgame-perfect strategy is Nash at every proper subgame of
+    the root. -/
+theorem IsSubgamePerfectOn.forall_properSubgame_isNashAt
+    {σ : Strategy ι U} {g : GameTree ι U}
+    (hspe : IsSubgamePerfectOn σ g) :
+    ∀ s : GameTree ι U, ProperSubgame s g → IsNashAt σ s :=
+  fun _ hproper => hspe.toNashAt_of_properSubgame hproper
+
+/-- Root-scoped subgame perfection gives root Nash equilibrium together with
+    Nash equilibrium at every proper subgame. -/
+theorem IsSubgamePerfectOn.toNashAt_and_forall_properSubgame_isNashAt
+    {σ : Strategy ι U} {g : GameTree ι U}
+    (hspe : IsSubgamePerfectOn σ g) :
+    IsNashAt σ g ∧
+      ∀ s : GameTree ι U, ProperSubgame s g → IsNashAt σ s :=
+  ⟨hspe.toNashAt, hspe.forall_properSubgame_isNashAt⟩
+
+/-- Root-scoped subgame perfection gives root Nash equilibrium together with
+    root-scoped subgame perfection on every proper subgame. -/
+theorem IsSubgamePerfectOn.toNashAt_and_forall_properSubgame_isSubgamePerfectOn
+    {σ : Strategy ι U} {g : GameTree ι U}
+    (hspe : IsSubgamePerfectOn σ g) :
+    IsNashAt σ g ∧
+      ∀ s : GameTree ι U, ProperSubgame s g → IsSubgamePerfectOn σ s :=
+  ⟨hspe.toNashAt, hspe.forall_properSubgame_isSubgamePerfectOn⟩
+
+/-- Root Nash equilibrium together with Nash equilibrium at every proper
+    subgame gives root-scoped subgame perfection. -/
+theorem IsNashAt.toSubgamePerfectOn_of_forall_properSubgame_isNashAt
+    {σ : Strategy ι U} {g : GameTree ι U}
+    (hnash : IsNashAt σ g)
+    (hproper : ∀ s : GameTree ι U, ProperSubgame s g → IsNashAt σ s) :
+    IsSubgamePerfectOn σ g := by
+  intro s hsub
+  rcases hsub.eq_or_properSubgame with rfl | hs
+  · exact hnash
+  · exact hproper s hs
+
+/-- Root Nash equilibrium together with root-scoped subgame perfection on every
+    proper subgame gives root-scoped subgame perfection. -/
+theorem IsNashAt.toSubgamePerfectOn_of_forall_properSubgame_isSubgamePerfectOn
+    {σ : Strategy ι U} {g : GameTree ι U}
+    (hnash : IsNashAt σ g)
+    (hproper :
+      ∀ s : GameTree ι U, ProperSubgame s g → IsSubgamePerfectOn σ s) :
+    IsSubgamePerfectOn σ g := by
+  exact hnash.toSubgamePerfectOn_of_forall_properSubgame_isNashAt
+    (fun s hs => (hproper s hs).toNashAt)
+
+/-- Root-scoped subgame perfection is equivalent to Nash equilibrium at the
+    root together with Nash equilibrium at every proper subgame. This is the
+    proper-subgame formulation of the pure finite-tree form of MSZ Definition
+    7.2. -/
+theorem isSubgamePerfectOn_iff_isNashAt_and_forall_properSubgame_isNashAt
+    {σ : Strategy ι U} {g : GameTree ι U} :
+    IsSubgamePerfectOn σ g ↔
+      IsNashAt σ g ∧
+        ∀ s : GameTree ι U, ProperSubgame s g → IsNashAt σ s := by
+  constructor
+  · intro hspe
+    exact hspe.toNashAt_and_forall_properSubgame_isNashAt
+  · rintro ⟨hnash, hproper⟩
+    exact hnash.toSubgamePerfectOn_of_forall_properSubgame_isNashAt hproper
+
+/-- Root-scoped subgame perfection is equivalent to Nash equilibrium at the
+    root together with root-scoped subgame perfection on every proper subgame. -/
+theorem isSubgamePerfectOn_iff_isNashAt_and_forall_properSubgame_isSubgamePerfectOn
+    {σ : Strategy ι U} {g : GameTree ι U} :
+    IsSubgamePerfectOn σ g ↔
+      IsNashAt σ g ∧
+        ∀ s : GameTree ι U, ProperSubgame s g → IsSubgamePerfectOn σ s := by
+  constructor
+  · intro hspe
+    exact hspe.toNashAt_and_forall_properSubgame_isSubgamePerfectOn
+  · rintro ⟨hnash, hproper⟩
+    exact hnash.toSubgamePerfectOn_of_forall_properSubgame_isSubgamePerfectOn
+      hproper
+
+/-- Existence of one strategy that is Nash at every subtree of a root is
+    equivalent to existence of a root-scoped subgame-perfect strategy. -/
+theorem exists_forall_subtree_isNashAt_iff_exists_isSubgamePerfectOn
+    (g : GameTree ι U) :
+    (∃ σ : Strategy ι U, ∀ s : GameTree ι U, Subtree s g → IsNashAt σ s) ↔
+      ∃ σ : Strategy ι U, IsSubgamePerfectOn σ g := by
+  constructor
+  · rintro ⟨σ, hnash⟩
+    exact ⟨σ, IsNashAt.toSubgamePerfectOn_of_forall_subtree_isNashAt hnash⟩
+  · rintro ⟨σ, hspe⟩
+    exact ⟨σ, hspe.forall_subtree_isNashAt⟩
+
+/-- Existence of one strategy that is root-scoped subgame-perfect on every
+    subtree is equivalent to existence of a root-scoped subgame-perfect
+    strategy at the root. -/
+theorem exists_forall_subtree_isSubgamePerfectOn_iff_exists_isSubgamePerfectOn
+    (g : GameTree ι U) :
+    (∃ σ : Strategy ι U,
+      ∀ s : GameTree ι U, Subtree s g → IsSubgamePerfectOn σ s) ↔
+      ∃ σ : Strategy ι U, IsSubgamePerfectOn σ g := by
+  constructor
+  · rintro ⟨σ, hsubtrees⟩
+    exact ⟨σ, IsSubgamePerfectOn.of_forall_subtree_isSubgamePerfectOn hsubtrees⟩
+  · rintro ⟨σ, hspe⟩
+    exact ⟨σ, hspe.forall_subtree_isSubgamePerfectOn⟩
+
+/-- Existence of one root Nash equilibrium that is also Nash at every proper
+    subgame is equivalent to existence of a root-scoped subgame-perfect
+    strategy. -/
+theorem exists_isNashAt_and_forall_properSubgame_isNashAt_iff_exists_isSubgamePerfectOn
+    (g : GameTree ι U) :
+    (∃ σ : Strategy ι U,
+      IsNashAt σ g ∧
+        ∀ s : GameTree ι U, ProperSubgame s g → IsNashAt σ s) ↔
+      ∃ σ : Strategy ι U, IsSubgamePerfectOn σ g := by
+  constructor
+  · rintro ⟨σ, hnash, hproper⟩
+    exact ⟨σ, hnash.toSubgamePerfectOn_of_forall_properSubgame_isNashAt hproper⟩
+  · rintro ⟨σ, hspe⟩
+    exact ⟨σ, hspe.toNashAt, hspe.forall_properSubgame_isNashAt⟩
+
+/-- Existence of one root Nash equilibrium whose proper subgames are
+    root-scoped subgame-perfect is equivalent to existence of a root-scoped
+    subgame-perfect strategy. -/
+theorem exists_isNashAt_and_forall_properSubgame_isSubgamePerfectOn_iff_exists_isSubgamePerfectOn
+    (g : GameTree ι U) :
+    (∃ σ : Strategy ι U,
+      IsNashAt σ g ∧
+        ∀ s : GameTree ι U, ProperSubgame s g → IsSubgamePerfectOn σ s) ↔
+      ∃ σ : Strategy ι U, IsSubgamePerfectOn σ g := by
+  constructor
+  · rintro ⟨σ, hnash, hproper⟩
+    exact ⟨σ, hnash.toSubgamePerfectOn_of_forall_properSubgame_isSubgamePerfectOn hproper⟩
+  · rintro ⟨σ, hspe⟩
+    exact ⟨σ, hspe.toNashAt, hspe.forall_properSubgame_isSubgamePerfectOn⟩
+
+/-- Root-scoped subgame perfection at a node restricts to its head child. -/
+theorem IsSubgamePerfectOn.head
+    {σ : Strategy ι U} {m : ι} {h : GameTree ι U} {t : List (GameTree ι U)}
+    (hspe : IsSubgamePerfectOn σ (Node m h t)) :
+    IsSubgamePerfectOn σ h :=
+  hspe.of_subtree (Subtree.head m h t)
+
+/-- Root-scoped subgame perfection at a node restricts to every tail child. -/
+theorem IsSubgamePerfectOn.tail_mem
+    {σ : Strategy ι U} {m : ι} {h : GameTree ι U} {t : List (GameTree ι U)}
+    {c : GameTree ι U} (hspe : IsSubgamePerfectOn σ (Node m h t))
+    (hmem : c ∈ t) :
+    IsSubgamePerfectOn σ c :=
+  hspe.of_subtree (Subtree.tail_mem m h t hmem)
+
+/-- Root-scoped subgame perfection at a node restricts to every direct child. -/
+theorem IsSubgamePerfectOn.child_mem
+    {σ : Strategy ι U} {m : ι} {h : GameTree ι U} {t : List (GameTree ι U)}
+    {c : GameTree ι U} (hspe : IsSubgamePerfectOn σ (Node m h t))
+    (hmem : c ∈ h :: t) :
+    IsSubgamePerfectOn σ c :=
+  hspe.of_subtree (Subtree.child_mem m h t hmem)
+
+/-- Root-scoped subgame perfection at a node restricts to every child in the
+    public `children` list. -/
+theorem IsSubgamePerfectOn.child
+    {σ : Strategy ι U} {m : ι} {h : GameTree ι U} {t : List (GameTree ι U)}
+    {c : GameTree ι U} (hspe : IsSubgamePerfectOn σ (Node m h t))
+    (hmem : c ∈ children (Node m h t)) :
+    IsSubgamePerfectOn σ c :=
+  hspe.of_subtree (Subtree.child m h t hmem)
+
+/-- Root-scoped subgame perfection at a node gives Nash equilibrium at its
+    head child. -/
+theorem IsSubgamePerfectOn.toNashAt_head
+    {σ : Strategy ι U} {m : ι} {h : GameTree ι U} {t : List (GameTree ι U)}
+    (hspe : IsSubgamePerfectOn σ (Node m h t)) :
+    IsNashAt σ h :=
+  hspe.head.toNashAt
+
+/-- Root-scoped subgame perfection at a node gives Nash equilibrium at every
+    tail child. -/
+theorem IsSubgamePerfectOn.toNashAt_tail_mem
+    {σ : Strategy ι U} {m : ι} {h : GameTree ι U} {t : List (GameTree ι U)}
+    {c : GameTree ι U} (hspe : IsSubgamePerfectOn σ (Node m h t))
+    (hmem : c ∈ t) :
+    IsNashAt σ c :=
+  (hspe.tail_mem hmem).toNashAt
+
+/-- Root-scoped subgame perfection at a node gives Nash equilibrium at every
+    direct child. -/
+theorem IsSubgamePerfectOn.toNashAt_child_mem
+    {σ : Strategy ι U} {m : ι} {h : GameTree ι U} {t : List (GameTree ι U)}
+    {c : GameTree ι U} (hspe : IsSubgamePerfectOn σ (Node m h t))
+    (hmem : c ∈ h :: t) :
+    IsNashAt σ c :=
+  (hspe.child_mem hmem).toNashAt
+
+/-- Root-scoped subgame perfection at a node gives Nash equilibrium at every
+    child in the public `children` list. -/
+theorem IsSubgamePerfectOn.toNashAt_child
+    {σ : Strategy ι U} {m : ι} {h : GameTree ι U} {t : List (GameTree ι U)}
+    {c : GameTree ι U} (hspe : IsSubgamePerfectOn σ (Node m h t))
+    (hmem : c ∈ children (Node m h t)) :
+    IsNashAt σ c :=
+  (hspe.child hmem).toNashAt
+
+/-- Root-scoped subgame perfection can be checked recursively at a nonterminal
+    node: Nash equilibrium at the node itself, plus root-scoped subgame
+    perfection on every direct child. -/
+theorem isSubgamePerfectOn_Node_iff
+    {σ : Strategy ι U} {m : ι} {h : GameTree ι U} {t : List (GameTree ι U)} :
+    IsSubgamePerfectOn σ (Node m h t) ↔
+      IsNashAt σ (Node m h t) ∧
+        IsSubgamePerfectOn σ h ∧
+          ∀ c ∈ t, IsSubgamePerfectOn σ c := by
+  constructor
+  · intro hspe
+    exact ⟨hspe.toNashAt,
+      hspe.of_subtree (Subtree.head m h t),
+      fun c hmem => hspe.of_subtree (Subtree.tail_mem m h t hmem)⟩
+  · rintro ⟨hnash, hhead, htail⟩
+    intro s hsub
+    cases hsub with
+    | refl =>
+        exact hnash
+    | inHead m h t hs =>
+        exact hhead.toNashAt_of_subtree hs
+    | inTail m h t hmem hs =>
+        exact (htail _ hmem).toNashAt_of_subtree hs
+
+/-- Root-scoped subgame perfection at a nonterminal node gives root Nash
+    equilibrium together with root-scoped subgame perfection on the head child
+    and every tail child. -/
+theorem IsSubgamePerfectOn.toNashAt_and_head_tail
+    {σ : Strategy ι U} {m : ι} {h : GameTree ι U} {t : List (GameTree ι U)}
+    (hspe : IsSubgamePerfectOn σ (Node m h t)) :
+    IsNashAt σ (Node m h t) ∧
+      IsSubgamePerfectOn σ h ∧
+        ∀ c ∈ t, IsSubgamePerfectOn σ c :=
+  (isSubgamePerfectOn_Node_iff).mp hspe
+
+/-- Root Nash equilibrium at a node, together with root-scoped subgame
+    perfection on each direct child, gives root-scoped subgame perfection at
+    the node. -/
+theorem IsNashAt.toSubgamePerfectOn_Node
+    {σ : Strategy ι U} {m : ι} {h : GameTree ι U} {t : List (GameTree ι U)}
+    (hnash : IsNashAt σ (Node m h t))
+    (hhead : IsSubgamePerfectOn σ h)
+    (htail : ∀ c ∈ t, IsSubgamePerfectOn σ c) :
+    IsSubgamePerfectOn σ (Node m h t) :=
+  (isSubgamePerfectOn_Node_iff).mpr ⟨hnash, hhead, htail⟩
+
+/-- Root-scoped subgame perfection at a nonterminal node is equivalent to root
+    Nash equilibrium plus root-scoped subgame perfection on every child in the
+    public `children` list. -/
+theorem isSubgamePerfectOn_Node_iff_children
+    {σ : Strategy ι U} {m : ι} {h : GameTree ι U} {t : List (GameTree ι U)} :
+    IsSubgamePerfectOn σ (Node m h t) ↔
+      IsNashAt σ (Node m h t) ∧
+        ∀ c ∈ children (Node m h t), IsSubgamePerfectOn σ c := by
+  rw [isSubgamePerfectOn_Node_iff]
+  constructor
+  · rintro ⟨hnash, hhead, htail⟩
+    refine ⟨hnash, ?_⟩
+    intro c hmem
+    rcases List.mem_cons.mp (by simpa [children] using hmem) with rfl | hmem'
+    · exact hhead
+    · exact htail c hmem'
+  · rintro ⟨hnash, hchildren⟩
+    refine ⟨hnash, ?_, ?_⟩
+    · exact hchildren h (by simp [children])
+    · intro c hmem
+      exact hchildren c (by simp [children, hmem])
+
+/-- Root-scoped subgame perfection at a nonterminal node gives root Nash
+    equilibrium together with root-scoped subgame perfection on every child in
+    the public `children` list. -/
+theorem IsSubgamePerfectOn.toNashAt_and_children
+    {σ : Strategy ι U} {m : ι} {h : GameTree ι U} {t : List (GameTree ι U)}
+    (hspe : IsSubgamePerfectOn σ (Node m h t)) :
+    IsNashAt σ (Node m h t) ∧
+      ∀ c ∈ children (Node m h t), IsSubgamePerfectOn σ c :=
+  (isSubgamePerfectOn_Node_iff_children).mp hspe
+
+/-- Root Nash equilibrium at a node, together with root-scoped subgame
+    perfection on every child in the public `children` list, gives root-scoped
+    subgame perfection at the node. -/
+theorem IsNashAt.toSubgamePerfectOn_Node_of_children
+    {σ : Strategy ι U} {m : ι} {h : GameTree ι U} {t : List (GameTree ι U)}
+    (hnash : IsNashAt σ (Node m h t))
+    (hchildren : ∀ c ∈ children (Node m h t), IsSubgamePerfectOn σ c) :
+    IsSubgamePerfectOn σ (Node m h t) :=
+  (isSubgamePerfectOn_Node_iff_children).mpr ⟨hnash, hchildren⟩
+
+/-- Existence of one strategy satisfying the head/tail recursive SPE check at
+    a node is equivalent to existence of a root-scoped SPE at that node. -/
+theorem exists_isNashAt_and_child_isSubgamePerfectOn_iff_exists_isSubgamePerfectOn_Node
+    (m : ι) (h : GameTree ι U) (t : List (GameTree ι U)) :
+    (∃ σ : Strategy ι U,
+      IsNashAt σ (Node m h t) ∧
+        IsSubgamePerfectOn σ h ∧
+          ∀ c ∈ t, IsSubgamePerfectOn σ c) ↔
+      ∃ σ : Strategy ι U, IsSubgamePerfectOn σ (Node m h t) := by
+  constructor
+  · rintro ⟨σ, hnash, hhead, htail⟩
+    exact ⟨σ, hnash.toSubgamePerfectOn_Node hhead htail⟩
+  · rintro ⟨σ, hspe⟩
+    exact ⟨σ, hspe.toNashAt_and_head_tail⟩
+
+/-- Existence of one strategy satisfying the children-list recursive SPE check
+    at a node is equivalent to existence of a root-scoped SPE at that node. -/
+theorem exists_isNashAt_and_children_isSubgamePerfectOn_iff_exists_isSubgamePerfectOn_Node
+    (m : ι) (h : GameTree ι U) (t : List (GameTree ι U)) :
+    (∃ σ : Strategy ι U,
+      IsNashAt σ (Node m h t) ∧
+        ∀ c ∈ children (Node m h t), IsSubgamePerfectOn σ c) ↔
+      ∃ σ : Strategy ι U, IsSubgamePerfectOn σ (Node m h t) := by
+  constructor
+  · rintro ⟨σ, hnash, hchildren⟩
+    exact ⟨σ, hnash.toSubgamePerfectOn_Node_of_children hchildren⟩
+  · rintro ⟨σ, hspe⟩
+    exact ⟨σ, hspe.toNashAt_and_children⟩
 
 /-- If a tree has no proper subgames, root Nash equilibrium already implies
     subgame perfection on that tree. This is the pure finite-tree form of
     MSZ Theorem 7.4. -/
 theorem IsNashAt.toSubgamePerfectOn_of_hasOnlyRootSubgames
-    {σ : Strategy N U} {g : GameTree N U}
+    {σ : Strategy ι U} {g : GameTree ι U}
     (hnash : IsNashAt σ g) (hsubgames : HasOnlyRootSubgames g) :
     IsSubgamePerfectOn σ g := by
   intro s hsg i σ' hiv
@@ -105,19 +685,200 @@ theorem IsNashAt.toSubgamePerfectOn_of_hasOnlyRootSubgames
   subst hs
   exact hnash i σ' hiv
 
+/-- On a tree with no proper subgames, root-scoped subgame perfection is
+    equivalent to root Nash equilibrium. This is the iff form of the pure
+    finite-tree version of MSZ Theorem 7.4. -/
+theorem isSubgamePerfectOn_iff_isNashAt_of_hasOnlyRootSubgames
+    {σ : Strategy ι U} {g : GameTree ι U} (hsubgames : HasOnlyRootSubgames g) :
+    IsSubgamePerfectOn σ g ↔ IsNashAt σ g := by
+  constructor
+  · intro hspe
+    exact hspe.toNashAt
+  · intro hnash
+    exact hnash.toSubgamePerfectOn_of_hasOnlyRootSubgames hsubgames
+
+/-- If the root has no proper subgame, then root Nash equilibrium and
+    root-scoped subgame perfection coincide. This is the pure finite-tree form
+    of MSZ Theorem 7.4. -/
+theorem isSubgamePerfectOn_iff_isNashAt_of_no_properSubgame
+    {σ : Strategy ι U} {g : GameTree ι U}
+    (hnoProper : ¬ ∃ s : GameTree ι U, ProperSubgame s g) :
+    IsSubgamePerfectOn σ g ↔ IsNashAt σ g :=
+  isSubgamePerfectOn_iff_isNashAt_of_hasOnlyRootSubgames
+    ((hasOnlyRootSubgames_iff_no_properSubgame g).mpr hnoProper)
+
+/-- On a tree with no proper subgames, existence of root-scoped subgame
+    perfection is equivalent to existence of root Nash equilibrium. -/
+theorem exists_isSubgamePerfectOn_iff_exists_isNashAt_of_hasOnlyRootSubgames
+    (g : GameTree ι U) (hsubgames : HasOnlyRootSubgames g) :
+    (∃ σ : Strategy ι U, IsSubgamePerfectOn σ g) ↔
+      ∃ σ : Strategy ι U, IsNashAt σ g := by
+  constructor
+  · rintro ⟨σ, hspe⟩
+    exact ⟨σ, hspe.toNashAt⟩
+  · rintro ⟨σ, hnash⟩
+    exact ⟨σ, hnash.toSubgamePerfectOn_of_hasOnlyRootSubgames hsubgames⟩
+
+/-- If the root has no proper subgame, existence of root-scoped subgame
+    perfection is equivalent to existence of root Nash equilibrium. -/
+theorem exists_isSubgamePerfectOn_iff_exists_isNashAt_of_no_properSubgame
+    (g : GameTree ι U)
+    (hnoProper : ¬ ∃ s : GameTree ι U, ProperSubgame s g) :
+    (∃ σ : Strategy ι U, IsSubgamePerfectOn σ g) ↔
+      ∃ σ : Strategy ι U, IsNashAt σ g :=
+  exists_isSubgamePerfectOn_iff_exists_isNashAt_of_hasOnlyRootSubgames g
+    ((hasOnlyRootSubgames_iff_no_properSubgame g).mpr hnoProper)
+
+/-- The canonical backward-induction strategy is root-scoped subgame-perfect
+    at every finite perfect-information root. -/
+theorem optStrategy_isSubgamePerfectOn (g : GameTree ι U) :
+    IsSubgamePerfectOn (optStrategy : Strategy ι U) g :=
+  optStrategy_isSubgamePerfect.toSubgamePerfectOn g
+
+/-- The canonical backward-induction strategy is Nash at every finite
+    perfect-information root. -/
+theorem optStrategy_isNashAt (g : GameTree ι U) :
+    IsNashAt (optStrategy : Strategy ι U) g :=
+  optStrategy_isSubgamePerfect.toNashAt g
+
+/-- The canonical backward-induction strategy is root-scoped subgame-perfect
+    on every subtree of a fixed finite perfect-information root. -/
+theorem optStrategy_isSubgamePerfectOn_subtree {s g : GameTree ι U}
+    (hsub : Subtree s g) :
+    IsSubgamePerfectOn (optStrategy : Strategy ι U) s :=
+  (optStrategy_isSubgamePerfectOn g).of_subtree hsub
+
+/-- The canonical backward-induction strategy is Nash at every subtree of a
+    fixed finite perfect-information root. -/
+theorem optStrategy_isNashAt_subtree {s g : GameTree ι U}
+    (hsub : Subtree s g) :
+    IsNashAt (optStrategy : Strategy ι U) s :=
+  (optStrategy_isSubgamePerfectOn g).toNashAt_of_subtree hsub
+
+/-- The canonical backward-induction strategy is root-scoped subgame-perfect
+    on every proper subgame of a fixed finite perfect-information root. -/
+theorem optStrategy_isSubgamePerfectOn_properSubgame {s g : GameTree ι U}
+    (hproper : ProperSubgame s g) :
+    IsSubgamePerfectOn (optStrategy : Strategy ι U) s :=
+  (optStrategy_isSubgamePerfectOn g).of_properSubgame hproper
+
+/-- The canonical backward-induction strategy is Nash at every proper subgame
+    of a fixed finite perfect-information root. -/
+theorem optStrategy_isNashAt_properSubgame {s g : GameTree ι U}
+    (hproper : ProperSubgame s g) :
+    IsNashAt (optStrategy : Strategy ι U) s :=
+  (optStrategy_isSubgamePerfectOn g).toNashAt_of_properSubgame hproper
+
 /-- **Kuhn's theorem, NE form**: every finite perfect-information game
     without chance has a pure-strategy Nash equilibrium. -/
-theorem Kuhn_exists_NE [DecidableLE U] (g : GameTree N U) :
-    ∃ σ : Strategy N U, IsNashEquilibrium σ g := by
-  obtain ⟨σ, hspe⟩ := Kuhn_exists_SPE (N := N) (U := U)
-  exact ⟨σ, hspe.toNE g⟩
+theorem Kuhn_exists_NE (g : GameTree ι U) :
+    ∃ σ : Strategy ι U, IsNashEquilibrium σ g := by
+  exact ⟨optStrategy, optStrategy_isNashAt g⟩
 
 /-- **Kuhn's theorem, root-scoped SPE form**: every finite perfect-information
     game without chance has a pure strategy that is subgame-perfect on that
     root. -/
-theorem Kuhn_exists_SPE_on [DecidableLE U] (g : GameTree N U) :
-    ∃ σ : Strategy N U, IsSubgamePerfectOn σ g := by
-  obtain ⟨σ, hspe⟩ := Kuhn_exists_SPE (N := N) (U := U)
-  exact ⟨σ, hspe.toSubgamePerfectOn g⟩
+theorem Kuhn_exists_SPE_on (g : GameTree ι U) :
+    ∃ σ : Strategy ι U, IsSubgamePerfectOn σ g := by
+  exact ⟨optStrategy, optStrategy_isSubgamePerfectOn g⟩
+
+/-- **Kuhn's theorem, all-roots SPE-on form**: one pure strategy is
+    root-scoped subgame-perfect at every finite perfect-information root. -/
+theorem Kuhn_exists_SPE_on_all_roots :
+    ∃ σ : Strategy ι U, ∀ g : GameTree ι U, IsSubgamePerfectOn σ g := by
+  exact ⟨optStrategy, optStrategy_isSubgamePerfectOn⟩
+
+/-- **Kuhn's theorem, all-roots NE form**: one pure strategy is Nash at every
+    finite perfect-information root. -/
+theorem Kuhn_exists_NE_on_all_roots :
+    ∃ σ : Strategy ι U, ∀ g : GameTree ι U, IsNashAt σ g := by
+  exact ⟨optStrategy, optStrategy_isNashAt⟩
+
+/-- **Kuhn's theorem, subtree SPE form**: every finite perfect-information game
+    without chance has a pure strategy that is subgame-perfect on every subtree
+    of a fixed root. -/
+theorem Kuhn_exists_SPE_on_subtrees (g : GameTree ι U) :
+    ∃ σ : Strategy ι U,
+      ∀ s : GameTree ι U, Subtree s g → IsSubgamePerfectOn σ s := by
+  obtain ⟨σ, hspe⟩ := Kuhn_exists_SPE_on g
+  exact ⟨σ, hspe.forall_subtree_isSubgamePerfectOn⟩
+
+/-- **Kuhn's theorem, subtree Nash form**: every finite perfect-information game
+    without chance has a pure strategy that is Nash at every subtree of a fixed
+    root. -/
+theorem Kuhn_exists_NE_on_subtrees (g : GameTree ι U) :
+    ∃ σ : Strategy ι U,
+      ∀ s : GameTree ι U, Subtree s g → IsNashAt σ s := by
+  obtain ⟨σ, hspe⟩ := Kuhn_exists_SPE_on g
+  exact ⟨σ, hspe.forall_subtree_isNashAt⟩
+
+/-- **Kuhn's theorem, fixed-subtree SPE form**: every subtree of a finite
+    perfect-information game has a pure strategy that is subgame-perfect at
+    that subtree root. -/
+theorem Kuhn_exists_SPE_on_subtree {s g : GameTree ι U} (_hsub : Subtree s g) :
+    ∃ σ : Strategy ι U, IsSubgamePerfectOn σ s :=
+  Kuhn_exists_SPE_on s
+
+/-- **Kuhn's theorem, fixed-subtree Nash form**: every subtree of a finite
+    perfect-information game has a pure-strategy Nash equilibrium at that
+    subtree root. -/
+theorem Kuhn_exists_NE_on_subtree {s g : GameTree ι U} (_hsub : Subtree s g) :
+    ∃ σ : Strategy ι U, IsNashAt σ s := by
+  obtain ⟨σ, hspe⟩ := Kuhn_exists_SPE_on_subtree _hsub
+  exact ⟨σ, hspe.toNashAt⟩
+
+/-- **Kuhn's theorem, proper-subgame SPE form**: every finite
+    perfect-information game has a pure strategy that is subgame-perfect on
+    every proper subgame of a fixed root. -/
+theorem Kuhn_exists_SPE_on_properSubgames (g : GameTree ι U) :
+    ∃ σ : Strategy ι U,
+      ∀ s : GameTree ι U, ProperSubgame s g → IsSubgamePerfectOn σ s := by
+  obtain ⟨σ, hspe⟩ := Kuhn_exists_SPE_on g
+  exact ⟨σ, hspe.forall_properSubgame_isSubgamePerfectOn⟩
+
+/-- **Kuhn's theorem, proper-subgame Nash form**: every finite
+    perfect-information game has a pure strategy that is Nash at every proper
+    subgame of a fixed root. -/
+theorem Kuhn_exists_NE_on_properSubgames (g : GameTree ι U) :
+    ∃ σ : Strategy ι U,
+      ∀ s : GameTree ι U, ProperSubgame s g → IsNashAt σ s := by
+  obtain ⟨σ, hspe⟩ := Kuhn_exists_SPE_on g
+  exact ⟨σ, hspe.forall_properSubgame_isNashAt⟩
+
+/-- **Kuhn's theorem, fixed proper-subgame SPE form**: every proper subgame of
+    a finite perfect-information game has a pure strategy that is
+    subgame-perfect at that subgame root. -/
+theorem Kuhn_exists_SPE_on_properSubgame {s g : GameTree ι U}
+    (hproper : ProperSubgame s g) :
+    ∃ σ : Strategy ι U, IsSubgamePerfectOn σ s :=
+  Kuhn_exists_SPE_on_subtree hproper.toSubtree
+
+/-- **Kuhn's theorem, fixed proper-subgame Nash form**: every proper subgame of
+    a finite perfect-information game has a pure-strategy Nash equilibrium at
+    that subgame root. -/
+theorem Kuhn_exists_NE_on_properSubgame {s g : GameTree ι U}
+    (hproper : ProperSubgame s g) :
+    ∃ σ : Strategy ι U, IsNashAt σ s :=
+  Kuhn_exists_NE_on_subtree hproper.toSubtree
+
+/-- **Kuhn's theorem, root/proper-subgame Nash form**: every finite
+    perfect-information game has one pure strategy that is Nash at the root and
+    Nash at every proper subgame. -/
+theorem Kuhn_exists_NE_and_NE_on_properSubgames (g : GameTree ι U) :
+    ∃ σ : Strategy ι U,
+      IsNashAt σ g ∧
+        ∀ s : GameTree ι U, ProperSubgame s g → IsNashAt σ s := by
+  obtain ⟨σ, hspe⟩ := Kuhn_exists_SPE_on g
+  exact ⟨σ, hspe.toNashAt_and_forall_properSubgame_isNashAt⟩
+
+/-- **Kuhn's theorem, root Nash/proper-subgame SPE form**: every finite
+    perfect-information game has one pure strategy that is Nash at the root and
+    subgame-perfect on every proper subgame. -/
+theorem Kuhn_exists_NE_and_SPE_on_properSubgames (g : GameTree ι U) :
+    ∃ σ : Strategy ι U,
+      IsNashAt σ g ∧
+        ∀ s : GameTree ι U, ProperSubgame s g → IsSubgamePerfectOn σ s := by
+  obtain ⟨σ, hspe⟩ := Kuhn_exists_SPE_on g
+  exact ⟨σ, hspe.toNashAt_and_forall_properSubgame_isSubgamePerfectOn⟩
 
 end GameTree

--- a/EconCSLib/GameTheory/ExtensiveGame/GameTreeNE.lean
+++ b/EconCSLib/GameTheory/ExtensiveGame/GameTreeNE.lean
@@ -162,12 +162,12 @@ theorem isSubgamePerfectOn_Leaf_iff {σ : Strategy ι U} {p : ι → U} :
     exact isSubgamePerfectOn_Leaf σ p
 
 /-- Every terminal leaf has a root-scoped Nash equilibrium. -/
-theorem exists_isNashAt_Leaf (p : ι → U) :
+theorem exists_isNashAt_Leaf [DecidableLE U] (p : ι → U) :
     ∃ σ : Strategy ι U, IsNashAt σ (Leaf p) := by
   exact ⟨optStrategy, isNashAt_Leaf optStrategy p⟩
 
 /-- Every terminal leaf has a root-scoped subgame-perfect equilibrium. -/
-theorem exists_isSubgamePerfectOn_Leaf (p : ι → U) :
+theorem exists_isSubgamePerfectOn_Leaf [DecidableLE U] (p : ι → U) :
     ∃ σ : Strategy ι U, IsSubgamePerfectOn σ (Leaf p) := by
   exact ⟨optStrategy, isSubgamePerfectOn_Leaf optStrategy p⟩
 
@@ -728,6 +728,8 @@ theorem exists_isSubgamePerfectOn_iff_exists_isNashAt_of_no_properSubgame
       ∃ σ : Strategy ι U, IsNashAt σ g :=
   exists_isSubgamePerfectOn_iff_exists_isNashAt_of_hasOnlyRootSubgames g
     ((hasOnlyRootSubgames_iff_no_properSubgame g).mpr hnoProper)
+
+variable [DecidableLE U]
 
 /-- The canonical backward-induction strategy is root-scoped subgame-perfect
     at every finite perfect-information root. -/

--- a/EconCSLib/GameTheory/ExtensiveGame/GameTreeSPE.lean
+++ b/EconCSLib/GameTheory/ExtensiveGame/GameTreeSPE.lean
@@ -14,8 +14,9 @@ subgame-perfect equilibrium, obtainable via backward induction.
 
 ## Minimal assumptions
 
-Only `[TotalPreorder U]` — preorder + totality, no antisymmetry,
-no decidability. See `ExtensiveGame/BackwardInduction.lean`.
+Only `[TotalPreorder U] [DecidableLE U]` — preorder + totality plus
+decidable comparison for the computable argmax used by backward induction.
+See `ExtensiveGame/BackwardInduction.lean`.
 
 ## Main definitions
 
@@ -43,7 +44,7 @@ no decidability. See `ExtensiveGame/BackwardInduction.lean`.
 
 namespace GameTree
 
-variable {ι U : Type*} [TotalPreorder U]
+variable {ι U : Type*} [TotalPreorder U] [DecidableLE U]
 
 /-! ### Strategies -/
 

--- a/EconCSLib/GameTheory/ExtensiveGame/GameTreeSPE.lean
+++ b/EconCSLib/GameTheory/ExtensiveGame/GameTreeSPE.lean
@@ -6,9 +6,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import EconCSLib.GameTheory.ExtensiveGame.BackwardInduction
 
 /-!
-# EconCSLib.GameTheory.ExtensiveGame.GameTreeSPE
+# ExtensiveGame.GameTreeSPE
 
-Strategies, outcomes, and **Kuhn's theorem** on `GameTree N U`:
+Strategies, outcomes, and **Kuhn's theorem** on `GameTree ι U`:
 every finite perfect-information game without chance has a
 subgame-perfect equilibrium, obtainable via backward induction.
 
@@ -31,30 +31,19 @@ no decidability. See `ExtensiveGame/BackwardInduction.lean`.
 ## Main results
 
 * `outcome_optStrategy_eq_value` — outcome of `optStrategy` is the BI value.
-* `optStrategy_isSubgamePerfect` — the backward-induction strategy `optStrategy`
-  is a subgame-perfect equilibrium (the substantive theorem).
-* `Kuhn_exists_SPE` — existence form: every finite perfect-information game has
-  an SPE.
-
-## A note on the name "Kuhn"
-
-"Kuhn's theorem" here means the **backward-induction / SPE-existence** theorem
-(Kuhn 1953). It is distinct from the *other* result also called Kuhn's theorem —
-the equivalence of mixed and behavioral strategies under perfect recall — whose
-infrastructure lives in `ExtensiveGame/BehaviorStrategy.lean` (tracked under
-EG-L2). Do not conflate the two.
+* `IVariant.symm` / `IVariant.trans` — unilateral-deviation variants form an
+  equivalence relation for each fixed player.
+* `Kuhn` — `optStrategy` is a subgame-perfect equilibrium.
+  Equivalently: every finite perfect-info game has an SPE.
 
 ## References
 
-* [MSZ, Ch. 3] Maschler, Solan, Zamir, *Game Theory* (Cambridge, 2013) —
-  backward induction on finite perfect-information games.
-* Kuhn, H. W. (1953), "Extensive Games and the Problem of Information," in
-  *Contributions to the Theory of Games, Vol. II*.
+* [MSZ] Maschler, Solan, Zamir, *Game Theory*, Theorem 3.13 (Kuhn).
 -/
 
 namespace GameTree
 
-variable {N U : Type*} [TotalPreorder U]
+variable {ι U : Type*} [TotalPreorder U]
 
 /-! ### Strategies -/
 
@@ -63,14 +52,14 @@ variable {N U : Type*} [TotalPreorder U]
 
     Note: a single `Strategy` covers all players. Player-`i` "strategies"
     are conceptualized as the restriction to nodes where `mover = i`. -/
-def Strategy (N U : Type*) : Type _ :=
-  (m : N) → (h : GameTree N U) → (t : List (GameTree N U)) →
-    { c : GameTree N U // c ∈ h :: t }
+def Strategy (ι U : Type*) : Type _ :=
+  (m : ι) → (h : GameTree ι U) → (t : List (GameTree ι U)) →
+    { c : GameTree ι U // c ∈ h :: t }
 
 /-- The outcome (terminal payoff vector) of playing strategy `σ` starting
     from game tree `g`. Walks down the tree, using `σ` to pick a child at
     each `Node`, until a `Leaf` is reached. -/
-noncomputable def outcome (σ : Strategy N U) : GameTree N U → (N → U)
+noncomputable def outcome (σ : Strategy ι U) : GameTree ι U → (ι → U)
   | Leaf p => p
   | Node m h t => outcome σ (σ m h t).val
 termination_by g => g.size
@@ -80,14 +69,14 @@ decreasing_by
 
 omit [TotalPreorder U] in
 @[simp]
-theorem outcome_Leaf (σ : Strategy N U) (p : N → U) :
+theorem outcome_Leaf (σ : Strategy ι U) (p : ι → U) :
     outcome σ (Leaf p) = p := by
   rw [outcome]
 
 omit [TotalPreorder U] in
 @[simp]
-theorem outcome_Node (σ : Strategy N U) (m : N) (h : GameTree N U)
-    (t : List (GameTree N U)) :
+theorem outcome_Node (σ : Strategy ι U) (m : ι) (h : GameTree ι U)
+    (t : List (GameTree ι U)) :
     outcome σ (Node m h t) = outcome σ (σ m h t).val := by
   rw [outcome]
 
@@ -98,13 +87,13 @@ theorem outcome_Node (σ : Strategy N U) (m : N) (h : GameTree N U)
     attaining the argmax for the mover).
 
     Noncomputable — uses classical choice via `value_Node_eq_some_child_value`. -/
-noncomputable def optStrategy [DecidableLE U] : Strategy N U := fun m h t =>
+noncomputable def optStrategy : Strategy ι U := fun m h t =>
   ⟨(value_Node_eq_some_child_value m h t).choose,
    (value_Node_eq_some_child_value m h t).choose_spec.1⟩
 
 /-- At a node, the `optStrategy` picks a child whose value equals the node's value. -/
-theorem value_optStrategy_eq [DecidableLE U] (m : N) (h : GameTree N U)
-    (t : List (GameTree N U)) :
+theorem value_optStrategy_eq (m : ι) (h : GameTree ι U)
+    (t : List (GameTree ι U)) :
     value (optStrategy m h t).val = value (Node m h t) :=
   ((value_Node_eq_some_child_value m h t).choose_spec.2).symm
 
@@ -112,22 +101,60 @@ theorem value_optStrategy_eq [DecidableLE U] (m : N) (h : GameTree N U)
 
 /-- Two strategies are `i`-variants if they agree on all nodes NOT owned by `i`.
     I.e., `σ'` is obtained from `σ` by changing only player `i`'s choices. -/
-def IVariant (i : N) (σ σ' : Strategy N U) : Prop :=
-  ∀ (m : N) (h : GameTree N U) (t : List (GameTree N U)),
+def IVariant (i : ι) (σ σ' : Strategy ι U) : Prop :=
+  ∀ (m : ι) (h : GameTree ι U) (t : List (GameTree ι U)),
     m ≠ i → σ m h t = σ' m h t
 
 omit [TotalPreorder U] in
 /-- `IVariant` is reflexive: any strategy is an `i`-variant of itself. -/
-theorem IVariant.refl (i : N) (σ : Strategy N U) : IVariant i σ σ :=
+theorem IVariant.refl (i : ι) (σ : Strategy ι U) : IVariant i σ σ :=
   fun _ _ _ _ => rfl
+
+omit [TotalPreorder U] in
+/-- An `i`-variant agrees with the original strategy at every node not owned
+    by player `i`. -/
+theorem IVariant.eq_of_mover_ne {i m : ι} {σ σ' : Strategy ι U}
+    (hiv : IVariant i σ σ') {h : GameTree ι U} {t : List (GameTree ι U)}
+    (hm : m ≠ i) :
+    σ m h t = σ' m h t :=
+  hiv m h t hm
+
+omit [TotalPreorder U] in
+/-- `IVariant` is symmetric. -/
+theorem IVariant.symm {i : ι} {σ σ' : Strategy ι U}
+    (hiv : IVariant i σ σ') :
+    IVariant i σ' σ :=
+  fun m h t hm => (hiv.eq_of_mover_ne (m := m) (h := h) (t := t) hm).symm
+
+omit [TotalPreorder U] in
+/-- `IVariant` is transitive. -/
+theorem IVariant.trans {i : ι} {σ σ' σ'' : Strategy ι U}
+    (hσσ' : IVariant i σ σ') (hσ'σ'' : IVariant i σ' σ'') :
+    IVariant i σ σ'' :=
+  fun m h t hm =>
+    (hσσ'.eq_of_mover_ne (m := m) (h := h) (t := t) hm).trans
+      (hσ'σ''.eq_of_mover_ne (m := m) (h := h) (t := t) hm)
+
+omit [TotalPreorder U] in
+/-- For each fixed player, `IVariant` is an equivalence relation on strategy
+    profiles. -/
+theorem IVariant.equivalence (i : ι) :
+    Equivalence (IVariant (U := U) i) where
+  refl := IVariant.refl i
+  symm := by
+    intro σ σ' hiv
+    exact hiv.symm
+  trans := by
+    intro σ σ' σ'' hσσ' hσ'σ''
+    exact hσσ'.trans hσ'σ''
 
 /-! ### Subgame-perfect equilibrium -/
 
 /-- A strategy is **subgame-perfect** (SPE) if, at every subtree, no player
     can strictly improve their payoff by a unilateral deviation — i.e., by
     switching to any `i`-variant strategy. -/
-def IsSubgamePerfect (σ : Strategy N U) : Prop :=
-  ∀ (g : GameTree N U) (i : N) (σ' : Strategy N U),
+def IsSubgamePerfect (σ : Strategy ι U) : Prop :=
+  ∀ (g : GameTree ι U) (i : ι) (σ' : Strategy ι U),
     IVariant i σ σ' → outcome σ' g i ≤ outcome σ g i
 
 /-! ### Kuhn's theorem (main result) -/
@@ -137,8 +164,8 @@ def IsSubgamePerfect (σ : Strategy N U) : Prop :=
 
     This is the bridge between `value` (defined via argmax) and `outcome`
     (defined via tree traversal). -/
-theorem outcome_optStrategy_eq_value [DecidableLE U] (g : GameTree N U) :
-    outcome (optStrategy : Strategy N U) g = value g := by
+theorem outcome_optStrategy_eq_value (g : GameTree ι U) :
+    outcome (optStrategy : Strategy ι U) g = value g := by
   induction g using GameTree.strong_induction with
   | base p => simp [outcome_Leaf, value_Leaf]
   | step m h t ih =>
@@ -154,8 +181,8 @@ theorem outcome_optStrategy_eq_value [DecidableLE U] (g : GameTree N U) :
     and every `i`-variant deviation `σ'`, the deviating outcome is no better
     than `optStrategy`'s outcome at coordinate `i`. This is the SPE property
     spelled out before bundling into existence form. -/
-theorem optStrategy_isSubgamePerfect [DecidableLE U] :
-    IsSubgamePerfect (optStrategy : Strategy N U) := by
+theorem optStrategy_isSubgamePerfect :
+    IsSubgamePerfect (optStrategy : Strategy ι U) := by
   intro g i σ' hiv
   induction g using GameTree.strong_induction with
   | base p =>
@@ -196,7 +223,7 @@ theorem optStrategy_isSubgamePerfect [DecidableLE U] :
     game without chance admits a subgame-perfect equilibrium.
 
     The backward-induction strategy `optStrategy` is such an SPE. -/
-theorem Kuhn_exists_SPE [DecidableLE U] : ∃ σ : Strategy N U, IsSubgamePerfect σ :=
+theorem Kuhn_exists_SPE : ∃ σ : Strategy ι U, IsSubgamePerfect σ :=
   ⟨optStrategy, optStrategy_isSubgamePerfect⟩
 
 end GameTree

--- a/EconCSLib/GameTheory/ExtensiveGame/GameTreeStrategicForm.lean
+++ b/EconCSLib/GameTheory/ExtensiveGame/GameTreeStrategicForm.lean
@@ -7,7 +7,7 @@ import EconCSLib.GameTheory.ExtensiveGame.GameTreeNE
 import EconCSLib.GameTheory.StrategicGame.NashEquilibrium
 
 /-!
-# EconCSLib.GameTheory.ExtensiveGame.GameTreeStrategicForm
+# ExtensiveGame.GameTreeStrategicForm
 
 Strategic-form extraction for finite perfect-information `GameTree` games.
 
@@ -20,48 +20,116 @@ children.  During play, the node's mover selects which player's plan is used.
 * `GameTree.PlayerStrategy` — one player's contingent plan on a `GameTree`.
 * `GameTree.profileStrategy` — combine a normal-form profile into a global tree
   strategy.
+* `GameTree.profileStrategy_surjective` — every global tree strategy is
+  represented by some normal-form profile.
+* `GameTree.optStrategyProfile` — the extracted normal-form profile induced by
+  backward induction.
 * `GameTree.toStrategicGame` — extracted pure normal-form game.
 
 ## Main results
 
 * `toStrategicGame_nash_iff_isNashAt` — pure Nash in the extracted game is
   exactly root-scoped Nash in the original tree.
+* `toStrategicGame_nash_toNashAt` / `IsNashAt.toStrategicGame_nash` — named
+  directions of the pure Nash/root Nash equivalence.
+* `exists_toStrategicGame_nash_iff_exists_isNashAt` — pure Nash existence in
+  the extracted game is exactly root-scoped Nash existence in the tree.
+* `toStrategicGame_nash_toSubgamePerfectOn_of_hasOnlyRootSubgames` — when the
+  root has no proper subgames, strategic-form Nash already gives root-scoped SPE.
+* `IsSubgamePerfectOn.toStrategicGame_nash` — root-scoped SPE induces a pure
+  Nash equilibrium in the extracted strategic-form game.
+* `IsSubgamePerfectOn.toStrategicGame_nash_of_subtree` — root-scoped SPE
+  induces pure Nash in the extracted game of each subtree.
+* `IsSubgamePerfectOn.exists_toStrategicGame_nash_of_subtree` — a tree-strategy
+  SPE witness is represented by a pure Nash profile on each subtree.
+* `isSubgamePerfectOn_iff_forall_subtree_toStrategicGame_nash` — root-scoped
+  SPE is equivalent to strategic-form Nash at every extracted subtree.
+* `exists_forall_subtree_toStrategicGame_nash_iff_exists_forall_subtree_isNashAt` —
+  subtree-wise strategic-form Nash existence is equivalent to subtree-wise
+  root Nash existence.
+* `exists_forall_subtree_toStrategicGame_nash_iff_exists_isSubgamePerfectOn` —
+  subtree-wise strategic-form Nash existence is equivalent to root-scoped SPE
+  existence.
+* `exists_toStrategicGame_nash_and_forall_properSubgame_isSubgamePerfectOn_iff_exists_isSubgamePerfectOn` —
+  root strategic-form Nash plus proper-subgame SPE existence is equivalent to
+  root-scoped SPE existence.
+* `isSubgamePerfectOn_iff_toStrategicGame_nash_and_forall_properSubgame_isSubgamePerfectOn` —
+  root-scoped SPE is root strategic-form Nash plus SPE on every proper subgame.
+* `isSubgamePerfectOn_Node_iff_toStrategicGame_nash_and_children` — recursive
+  node check using strategic-form Nash at the root and SPE on direct children.
+* `IsSubgamePerfectOn.toStrategicGame_nash_and_head_tail` — bundled node
+  decomposition into strategic-form root Nash plus head/tail SPE.
+* `isSubgamePerfect_iff_forall_toStrategicGame_nash` — global SPE is
+  equivalent to strategic-form Nash at every extracted root.
+* `Kuhn_exists_toStrategicGame_nash` — the extracted strategic-form game has a
+  pure Nash equilibrium, witnessed by the backward-induction strategy.
+* `Kuhn_exists_toStrategicGame_nash_and_SPE_on_properSubgames` — one
+  normal-form profile is root Nash and SPE on every proper subgame.
 -/
 
 namespace GameTree
 
-variable {N U : Type*}
-variable [DecidableEq N]
+variable {ι U : Type*}
 
 /-- A single player's pure strategy in the normal form of a `GameTree`:
     a complete contingent plan choosing a child at every possible node. -/
-def PlayerStrategy (N U : Type*) : Type _ :=
-  (m : N) → (h : GameTree N U) → (t : List (GameTree N U)) →
-    { c : GameTree N U // c ∈ h :: t }
+def PlayerStrategy (ι U : Type*) : Type _ :=
+  (m : ι) → (h : GameTree ι U) → (t : List (GameTree ι U)) →
+    { c : GameTree ι U // c ∈ h :: t }
 
 /-- Combine a normal-form profile into the global `GameTree.Strategy` used by
     the game-tree evaluator.  At each node, the mover's contingent plan is used. -/
-def profileStrategy (σ : N → PlayerStrategy N U) : Strategy N U :=
+def profileStrategy (σ : ι → PlayerStrategy ι U) : Strategy ι U :=
   fun m h t => σ m m h t
 
+/-- A global tree strategy is recovered from the constant normal-form profile
+    that assigns that complete contingent plan to every player. -/
+@[simp]
+theorem profileStrategy_const (τ : Strategy ι U) :
+    profileStrategy (fun _ : ι => (τ : PlayerStrategy ι U)) = τ :=
+  rfl
+
+/-- Every global tree strategy is represented by some extracted normal-form
+    profile. A constant profile containing the same complete contingent plan
+    for every player is enough. -/
+theorem profileStrategy_surjective :
+    Function.Surjective (profileStrategy : (ι → PlayerStrategy ι U) → Strategy ι U) :=
+  fun τ => ⟨fun _ : ι => (τ : PlayerStrategy ι U), profileStrategy_const τ⟩
+
+/-- The normal-form profile induced by the canonical backward-induction
+    strategy. Each player is assigned the same complete contingent plan
+    `optStrategy`; at a node, `profileStrategy` then reads the mover's plan. -/
+noncomputable def optStrategyProfile [TotalPreorder U] : ι → PlayerStrategy ι U :=
+  fun _ => (optStrategy : PlayerStrategy ι U)
+
+/-- Evaluating the backward-induction normal-form profile recovers the
+    canonical backward-induction tree strategy. -/
+@[simp]
+theorem profileStrategy_optStrategyProfile [TotalPreorder U] :
+    profileStrategy (optStrategyProfile : ι → PlayerStrategy ι U) =
+      (optStrategy : Strategy ι U) :=
+  rfl
+
+variable [DecidableEq ι]
+
 /-- The strategic-form extraction of a finite perfect-information tree. -/
-noncomputable def toStrategicGame (g : GameTree N U) : StrategicGame N U where
-  strategy := fun _ => PlayerStrategy N U
+noncomputable def toStrategicGame (g : GameTree ι U) : StrategicGame ι U where
+  strategy := fun _ => PlayerStrategy ι U
   payoff σ i := outcome (profileStrategy σ) g i
 
 /-- Replacing player `i`'s normal-form contingent plan produces an `i`-variant
     global tree strategy. -/
-theorem profileStrategy_deviate_variant (σ : N → PlayerStrategy N U)
-    (i : N) (s' : PlayerStrategy N U) :
+theorem profileStrategy_deviate_variant (σ : ι → PlayerStrategy ι U)
+    (i : ι) (s' : PlayerStrategy ι U) :
     IVariant i (profileStrategy σ) (profileStrategy (Function.update σ i s')) := by
   intro m h t hmi
   simp [profileStrategy, hmi]
 
 /-- Any global `i`-variant tree strategy can be represented by deviating player
     `i`'s normal-form contingent plan. -/
-theorem profileStrategy_deviate_eq_of_variant (σ : N → PlayerStrategy N U)
-    (i : N) (τ : Strategy N U) (hτ : IVariant i (profileStrategy σ) τ) :
-    profileStrategy (Function.update σ i (τ : PlayerStrategy N U)) = τ := by
+theorem profileStrategy_deviate_eq_of_variant (σ : ι → PlayerStrategy ι U)
+    (i : ι) (τ : Strategy ι U) (hτ : IVariant i (profileStrategy σ) τ) :
+    profileStrategy (Function.update σ i (τ : PlayerStrategy ι U)) = τ := by
   funext m h t
   by_cases hmi : m = i
   · subst hmi
@@ -73,16 +141,738 @@ variable [TotalPreorder U]
 
 /-- Nash equilibrium in the extracted strategic-form game is exactly Nash
     equilibrium at the root of the original tree. -/
-theorem toStrategicGame_nash_iff_isNashAt (g : GameTree N U)
+theorem toStrategicGame_nash_iff_isNashAt (g : GameTree ι U)
     (σ : (toStrategicGame g).Profile) :
     _root_.IsNashEquilibrium (toStrategicGame g) σ ↔ IsNashAt (profileStrategy σ) g := by
   constructor
   · intro hN i τ hτ
-    have hdev := hN i (τ : PlayerStrategy N U)
+    have hdev := hN i (τ : PlayerStrategy ι U)
     simpa [toStrategicGame, IsBestResponse, StrategicGame.deviate,
       profileStrategy_deviate_eq_of_variant σ i τ hτ] using hdev
   · intro hN i s'
     exact hN i (profileStrategy (Function.update σ i s'))
       (profileStrategy_deviate_variant σ i s')
+
+/-- Pure Nash equilibrium in the extracted strategic-form game gives root
+    Nash equilibrium for the induced tree strategy. -/
+theorem toStrategicGame_nash_toNashAt {g : GameTree ι U}
+    {σ : (toStrategicGame g).Profile}
+    (hnash : _root_.IsNashEquilibrium (toStrategicGame g) σ) :
+    IsNashAt (profileStrategy σ) g :=
+  (toStrategicGame_nash_iff_isNashAt g σ).mp hnash
+
+/-- Root Nash equilibrium for a represented tree strategy gives pure Nash
+    equilibrium in the extracted strategic-form game. -/
+theorem IsNashAt.toStrategicGame_nash {g : GameTree ι U}
+    {σ : (toStrategicGame g).Profile}
+    (hnash : IsNashAt (profileStrategy σ) g) :
+    _root_.IsNashEquilibrium (toStrategicGame g) σ :=
+  (toStrategicGame_nash_iff_isNashAt g σ).mpr hnash
+
+/-- Existence of a pure Nash equilibrium in the extracted strategic-form game
+    is equivalent to existence of a root-scoped Nash equilibrium in the
+    original game tree. -/
+theorem exists_toStrategicGame_nash_iff_exists_isNashAt (g : GameTree ι U) :
+    (∃ σ : (toStrategicGame g).Profile,
+      _root_.IsNashEquilibrium (toStrategicGame g) σ) ↔
+      ∃ τ : Strategy ι U, IsNashAt τ g := by
+  constructor
+  · rintro ⟨σ, hnash⟩
+    exact ⟨profileStrategy σ, (toStrategicGame_nash_iff_isNashAt g σ).mp hnash⟩
+  · rintro ⟨τ, hnash⟩
+    refine ⟨fun _ : ι => (τ : PlayerStrategy ι U), ?_⟩
+    exact (toStrategicGame_nash_iff_isNashAt g _).mpr (by
+      simpa using hnash)
+
+/-- A root-scoped Nash equilibrium in the game tree gives a pure Nash
+    equilibrium in the extracted strategic-form game by using the same complete
+    contingent plan for every player. -/
+theorem IsNashAt.exists_toStrategicGame_nash
+    {g : GameTree ι U} {τ : Strategy ι U} (hnash : IsNashAt τ g) :
+    ∃ σ : (toStrategicGame g).Profile,
+      _root_.IsNashEquilibrium (toStrategicGame g) σ :=
+  (exists_toStrategicGame_nash_iff_exists_isNashAt g).mpr ⟨τ, hnash⟩
+
+/-- A root-scoped subgame-perfect tree strategy gives a represented pure Nash
+    profile in the extracted strategic-form game at the same root. -/
+theorem IsSubgamePerfectOn.exists_toStrategicGame_nash
+    {g : GameTree ι U} {τ : Strategy ι U} (hspe : IsSubgamePerfectOn τ g) :
+    ∃ σ : (toStrategicGame g).Profile,
+      _root_.IsNashEquilibrium (toStrategicGame g) σ :=
+  hspe.toNashAt.exists_toStrategicGame_nash
+
+/-- A root-scoped subgame-perfect tree strategy gives a represented pure Nash
+    profile in the extracted strategic-form game of any subtree. -/
+theorem IsSubgamePerfectOn.exists_toStrategicGame_nash_of_subtree
+    {g s : GameTree ι U} {τ : Strategy ι U}
+    (hspe : IsSubgamePerfectOn τ g) (hsub : Subtree s g) :
+    ∃ σ : (toStrategicGame s).Profile,
+      _root_.IsNashEquilibrium (toStrategicGame s) σ :=
+  (hspe.toNashAt_of_subtree hsub).exists_toStrategicGame_nash
+
+/-- A root-scoped subgame-perfect tree strategy gives a represented pure Nash
+    profile in the extracted strategic-form game of any proper subgame. -/
+theorem IsSubgamePerfectOn.exists_toStrategicGame_nash_of_properSubgame
+    {g s : GameTree ι U} {τ : Strategy ι U}
+    (hspe : IsSubgamePerfectOn τ g) (hproper : ProperSubgame s g) :
+    ∃ σ : (toStrategicGame s).Profile,
+      _root_.IsNashEquilibrium (toStrategicGame s) σ :=
+  hspe.exists_toStrategicGame_nash_of_subtree hproper.toSubtree
+
+/-- The extracted strategic-form game of a terminal leaf has a pure Nash
+    equilibrium. -/
+theorem exists_toStrategicGame_nash_Leaf (p : ι → U) :
+    ∃ σ : (toStrategicGame (Leaf p : GameTree ι U)).Profile,
+      _root_.IsNashEquilibrium (toStrategicGame (Leaf p : GameTree ι U)) σ :=
+  (isNashAt_Leaf (optStrategy : Strategy ι U) p).exists_toStrategicGame_nash
+
+/-- On a terminal leaf, pure Nash existence in the extracted strategic-form
+    game is equivalent to root-scoped subgame-perfect existence. -/
+theorem exists_toStrategicGame_nash_Leaf_iff_exists_isSubgamePerfectOn
+    (p : ι → U) :
+    (∃ σ : (toStrategicGame (Leaf p : GameTree ι U)).Profile,
+      _root_.IsNashEquilibrium (toStrategicGame (Leaf p : GameTree ι U)) σ) ↔
+      ∃ τ : Strategy ι U, IsSubgamePerfectOn τ (Leaf p) := by
+  rw [exists_toStrategicGame_nash_iff_exists_isNashAt]
+  exact (exists_isSubgamePerfectOn_Leaf_iff_exists_isNashAt p).symm
+
+/-- If a finite perfect-information root has no proper subgames, then pure
+    Nash equilibrium in its extracted strategic-form game already gives
+    root-scoped subgame perfection. This is the strategic-form version of the
+    pure finite-tree form of MSZ Theorem 7.4. -/
+theorem toStrategicGame_nash_toSubgamePerfectOn_of_hasOnlyRootSubgames
+    {g : GameTree ι U} {σ : (toStrategicGame g).Profile}
+    (hnash : _root_.IsNashEquilibrium (toStrategicGame g) σ)
+    (hsubgames : HasOnlyRootSubgames g) :
+    IsSubgamePerfectOn (profileStrategy σ) g :=
+  ((toStrategicGame_nash_iff_isNashAt g σ).mp hnash).toSubgamePerfectOn_of_hasOnlyRootSubgames
+    hsubgames
+
+/-- On a finite perfect-information root with no proper subgames, pure Nash in
+    the extracted strategic-form game is equivalent to root-scoped subgame
+    perfection. This is the strategic-form iff form of MSZ Theorem 7.4. -/
+theorem isSubgamePerfectOn_iff_toStrategicGame_nash_of_hasOnlyRootSubgames
+    {g : GameTree ι U} (σ : (toStrategicGame g).Profile)
+    (hsubgames : HasOnlyRootSubgames g) :
+    IsSubgamePerfectOn (profileStrategy σ) g ↔
+      _root_.IsNashEquilibrium (toStrategicGame g) σ := by
+  constructor
+  · intro hspe
+    exact (toStrategicGame_nash_iff_isNashAt g σ).mpr hspe.toNashAt
+  · intro hnash
+    exact toStrategicGame_nash_toSubgamePerfectOn_of_hasOnlyRootSubgames hnash
+      hsubgames
+
+/-- If the root has no proper subgame, pure Nash in the extracted
+    strategic-form game is equivalent to root-scoped subgame perfection. -/
+theorem isSubgamePerfectOn_iff_toStrategicGame_nash_of_no_properSubgame
+    {g : GameTree ι U} (σ : (toStrategicGame g).Profile)
+    (hnoProper : ¬ ∃ s : GameTree ι U, ProperSubgame s g) :
+    IsSubgamePerfectOn (profileStrategy σ) g ↔
+      _root_.IsNashEquilibrium (toStrategicGame g) σ :=
+  isSubgamePerfectOn_iff_toStrategicGame_nash_of_hasOnlyRootSubgames σ
+    ((hasOnlyRootSubgames_iff_no_properSubgame g).mpr hnoProper)
+
+/-- Root-scoped subgame perfection in a finite perfect-information tree induces
+    a pure Nash equilibrium in the extracted strategic-form game. -/
+theorem IsSubgamePerfectOn.toStrategicGame_nash
+    {g : GameTree ι U} {σ : (toStrategicGame g).Profile}
+    (hspe : IsSubgamePerfectOn (profileStrategy σ) g) :
+    _root_.IsNashEquilibrium (toStrategicGame g) σ :=
+  (toStrategicGame_nash_iff_isNashAt g σ).mpr hspe.toNashAt
+
+/-- Global subgame perfection induces a pure Nash equilibrium in the extracted
+    strategic-form game for every finite perfect-information root. -/
+theorem IsSubgamePerfect.toStrategicGame_nash
+    {g : GameTree ι U} {σ : (toStrategicGame g).Profile}
+    (hspe : IsSubgamePerfect (profileStrategy σ)) :
+    _root_.IsNashEquilibrium (toStrategicGame g) σ :=
+  (hspe.toSubgamePerfectOn g).toStrategicGame_nash
+
+set_option linter.unusedSectionVars false in
+/-- If a global subgame-perfect tree strategy exists, then it is represented by
+    some normal-form profile. -/
+theorem exists_profileStrategy_isSubgamePerfect_of_exists_isSubgamePerfect
+    (hexists : ∃ τ : Strategy ι U, IsSubgamePerfect τ) :
+    ∃ σ : ι → PlayerStrategy ι U, IsSubgamePerfect (profileStrategy σ) := by
+  rcases hexists with ⟨τ, hspe⟩
+  exact ⟨fun _ : ι => (τ : PlayerStrategy ι U), by simpa using hspe⟩
+
+set_option linter.unusedSectionVars false in
+/-- Existence of a global subgame-perfect tree strategy is equivalent to
+    existence of a normal-form profile whose induced tree strategy is globally
+    subgame-perfect. -/
+theorem exists_profileStrategy_isSubgamePerfect_iff_exists_isSubgamePerfect :
+    (∃ σ : ι → PlayerStrategy ι U, IsSubgamePerfect (profileStrategy σ)) ↔
+      ∃ τ : Strategy ι U, IsSubgamePerfect τ := by
+  constructor
+  · rintro ⟨σ, hspe⟩
+    exact ⟨profileStrategy σ, hspe⟩
+  · exact exists_profileStrategy_isSubgamePerfect_of_exists_isSubgamePerfect
+
+set_option linter.unusedSectionVars false in
+/-- If a root-scoped subgame-perfect tree strategy exists, then it is
+    represented by some normal-form profile. -/
+theorem exists_profileStrategy_isSubgamePerfectOn_of_exists_isSubgamePerfectOn
+    (g : GameTree ι U)
+    (hexists : ∃ τ : Strategy ι U, IsSubgamePerfectOn τ g) :
+    ∃ σ : (toStrategicGame g).Profile,
+      IsSubgamePerfectOn (profileStrategy σ) g := by
+  rcases hexists with ⟨τ, hspe⟩
+  exact ⟨fun _ : ι => (τ : PlayerStrategy ι U), by simpa using hspe⟩
+
+set_option linter.unusedSectionVars false in
+/-- Existence of root-scoped subgame perfection in the tree is equivalent to
+    existence of a normal-form profile whose induced tree strategy is
+    root-scoped subgame-perfect. -/
+theorem exists_profileStrategy_isSubgamePerfectOn_iff_exists_isSubgamePerfectOn
+    (g : GameTree ι U) :
+    (∃ σ : (toStrategicGame g).Profile,
+      IsSubgamePerfectOn (profileStrategy σ) g) ↔
+      ∃ τ : Strategy ι U, IsSubgamePerfectOn τ g := by
+  constructor
+  · rintro ⟨σ, hspe⟩
+    exact ⟨profileStrategy σ, hspe⟩
+  · exact exists_profileStrategy_isSubgamePerfectOn_of_exists_isSubgamePerfectOn g
+
+/-- A global subgame-perfect strategy induces a pure Nash equilibrium in the
+    extracted strategic-form game of every finite perfect-information root. -/
+theorem IsSubgamePerfect.forall_toStrategicGame_nash
+    {σ : ι → PlayerStrategy ι U} (hspe : IsSubgamePerfect (profileStrategy σ)) :
+    ∀ g : GameTree ι U, _root_.IsNashEquilibrium (toStrategicGame g) σ :=
+  fun g => hspe.toStrategicGame_nash (g := g)
+
+/-- Global subgame perfection is equivalent to pure Nash equilibrium in every
+    extracted strategic-form game. -/
+theorem isSubgamePerfect_iff_forall_toStrategicGame_nash
+    (σ : ι → PlayerStrategy ι U) :
+    IsSubgamePerfect (profileStrategy σ) ↔
+      ∀ g : GameTree ι U, _root_.IsNashEquilibrium (toStrategicGame g) σ := by
+  constructor
+  · intro hspe
+    exact hspe.forall_toStrategicGame_nash
+  · intro hnash
+    exact IsSubgamePerfect.of_forall_isNashAt
+      (fun g => (toStrategicGame_nash_iff_isNashAt g σ).mp (hnash g))
+
+/-- Existence of one normal-form profile that is pure Nash in every extracted
+    strategic-form game is equivalent to existence of a global
+    subgame-perfect tree strategy. -/
+theorem exists_forall_toStrategicGame_nash_iff_exists_isSubgamePerfect :
+    (∃ σ : ι → PlayerStrategy ι U,
+      ∀ g : GameTree ι U, _root_.IsNashEquilibrium (toStrategicGame g) σ) ↔
+      ∃ τ : Strategy ι U, IsSubgamePerfect τ := by
+  constructor
+  · rintro ⟨σ, hnash⟩
+    exact ⟨profileStrategy σ,
+      IsSubgamePerfect.of_forall_isNashAt
+        (fun g => (toStrategicGame_nash_iff_isNashAt g σ).mp (hnash g))⟩
+  · rintro ⟨τ, hspe⟩
+    refine ⟨fun _ : ι => (τ : PlayerStrategy ι U), ?_⟩
+    intro g
+    exact (toStrategicGame_nash_iff_isNashAt g _).mpr (by
+      simpa using hspe.toNashAt g)
+
+/-- Root-scoped subgame perfection gives pure Nash equilibrium in the extracted
+    strategic-form game of every subtree of the root. -/
+theorem IsSubgamePerfectOn.forall_subtree_toStrategicGame_nash
+    {g : GameTree ι U} {σ : (toStrategicGame g).Profile}
+    (hspe : IsSubgamePerfectOn (profileStrategy σ) g) :
+    ∀ s : GameTree ι U, Subtree s g →
+      _root_.IsNashEquilibrium (toStrategicGame s) σ :=
+  fun s hsub =>
+    (toStrategicGame_nash_iff_isNashAt s σ).mpr
+      (hspe.toNashAt_of_subtree hsub)
+
+/-- Root-scoped subgame perfection gives pure Nash equilibrium in the
+    extracted strategic-form game of any fixed subtree of the root. -/
+theorem IsSubgamePerfectOn.toStrategicGame_nash_of_subtree
+    {g s : GameTree ι U} {σ : (toStrategicGame g).Profile}
+    (hspe : IsSubgamePerfectOn (profileStrategy σ) g) (hsub : Subtree s g) :
+    _root_.IsNashEquilibrium (toStrategicGame s) σ :=
+  (toStrategicGame_nash_iff_isNashAt s σ).mpr
+    (hspe.toNashAt_of_subtree hsub)
+
+/-- Root-scoped subgame perfection gives pure Nash equilibrium in the extracted
+    strategic-form game of every proper subgame of the root. -/
+theorem IsSubgamePerfectOn.forall_properSubgame_toStrategicGame_nash
+    {g : GameTree ι U} {σ : (toStrategicGame g).Profile}
+    (hspe : IsSubgamePerfectOn (profileStrategy σ) g) :
+    ∀ s : GameTree ι U, ProperSubgame s g →
+      _root_.IsNashEquilibrium (toStrategicGame s) σ :=
+  fun s hproper =>
+    (toStrategicGame_nash_iff_isNashAt s σ).mpr
+      (hspe.toNashAt_of_properSubgame hproper)
+
+/-- Root-scoped subgame perfection gives pure Nash equilibrium in the
+    extracted strategic-form game of any fixed proper subgame of the root. -/
+theorem IsSubgamePerfectOn.toStrategicGame_nash_of_properSubgame
+    {g s : GameTree ι U} {σ : (toStrategicGame g).Profile}
+    (hspe : IsSubgamePerfectOn (profileStrategy σ) g)
+    (hproper : ProperSubgame s g) :
+    _root_.IsNashEquilibrium (toStrategicGame s) σ :=
+  hspe.toStrategicGame_nash_of_subtree hproper.toSubtree
+
+/-- Root-scoped subgame perfection gives strategic-form root Nash together
+    with strategic-form Nash at every proper subgame. -/
+theorem IsSubgamePerfectOn.toStrategicGame_nash_and_forall_properSubgame_toStrategicGame_nash
+    {g : GameTree ι U} {σ : (toStrategicGame g).Profile}
+    (hspe : IsSubgamePerfectOn (profileStrategy σ) g) :
+    _root_.IsNashEquilibrium (toStrategicGame g) σ ∧
+      ∀ s : GameTree ι U, ProperSubgame s g →
+        _root_.IsNashEquilibrium (toStrategicGame s) σ :=
+  ⟨hspe.toStrategicGame_nash, hspe.forall_properSubgame_toStrategicGame_nash⟩
+
+/-- Root-scoped subgame perfection gives strategic-form root Nash together
+    with root-scoped subgame perfection on every proper subgame. -/
+theorem IsSubgamePerfectOn.toStrategicGame_nash_and_forall_properSubgame_isSubgamePerfectOn
+    {g : GameTree ι U} {σ : (toStrategicGame g).Profile}
+    (hspe : IsSubgamePerfectOn (profileStrategy σ) g) :
+    _root_.IsNashEquilibrium (toStrategicGame g) σ ∧
+      ∀ s : GameTree ι U, ProperSubgame s g →
+        IsSubgamePerfectOn (profileStrategy σ) s :=
+  ⟨hspe.toStrategicGame_nash, hspe.forall_properSubgame_isSubgamePerfectOn⟩
+
+/-- Root-scoped subgame perfection at a node gives pure Nash equilibrium in
+    the extracted strategic-form game of its head child. -/
+theorem IsSubgamePerfectOn.toStrategicGame_nash_head
+    {σ : ι → PlayerStrategy ι U}
+    {m : ι} {h : GameTree ι U} {t : List (GameTree ι U)}
+    (hspe : IsSubgamePerfectOn (profileStrategy σ) (Node m h t)) :
+    _root_.IsNashEquilibrium (toStrategicGame h) σ :=
+  (toStrategicGame_nash_iff_isNashAt h σ).mpr hspe.toNashAt_head
+
+/-- Root-scoped subgame perfection at a node gives pure Nash equilibrium in
+    the extracted strategic-form game of every tail child. -/
+theorem IsSubgamePerfectOn.toStrategicGame_nash_tail_mem
+    {σ : ι → PlayerStrategy ι U}
+    {m : ι} {h : GameTree ι U} {t : List (GameTree ι U)}
+    {c : GameTree ι U}
+    (hspe : IsSubgamePerfectOn (profileStrategy σ) (Node m h t)) (hmem : c ∈ t) :
+    _root_.IsNashEquilibrium (toStrategicGame c) σ :=
+  (toStrategicGame_nash_iff_isNashAt c σ).mpr
+    (hspe.toNashAt_tail_mem hmem)
+
+/-- Root-scoped subgame perfection at a node gives pure Nash equilibrium in
+    the extracted strategic-form game of every direct child. -/
+theorem IsSubgamePerfectOn.toStrategicGame_nash_child_mem
+    {σ : ι → PlayerStrategy ι U}
+    {m : ι} {h : GameTree ι U} {t : List (GameTree ι U)}
+    {c : GameTree ι U}
+    (hspe : IsSubgamePerfectOn (profileStrategy σ) (Node m h t)) (hmem : c ∈ h :: t) :
+    _root_.IsNashEquilibrium (toStrategicGame c) σ :=
+  (toStrategicGame_nash_iff_isNashAt c σ).mpr
+    (hspe.toNashAt_child_mem hmem)
+
+/-- Root-scoped subgame perfection at a node gives pure Nash equilibrium in
+    the extracted strategic-form game of every child in the public `children`
+    list. -/
+theorem IsSubgamePerfectOn.toStrategicGame_nash_child
+    {σ : ι → PlayerStrategy ι U}
+    {m : ι} {h : GameTree ι U} {t : List (GameTree ι U)}
+    {c : GameTree ι U}
+    (hspe : IsSubgamePerfectOn (profileStrategy σ) (Node m h t))
+    (hmem : c ∈ children (Node m h t)) :
+    _root_.IsNashEquilibrium (toStrategicGame c) σ :=
+  (toStrategicGame_nash_iff_isNashAt c σ).mpr
+    (hspe.toNashAt_child hmem)
+
+/-- Existence of one normal-form profile that is pure Nash in every extracted
+    subtree game is equivalent to existence of one tree strategy that is
+    root-scoped Nash at every subtree. -/
+theorem exists_forall_subtree_toStrategicGame_nash_iff_exists_forall_subtree_isNashAt
+    (g : GameTree ι U) :
+    (∃ σ : ι → PlayerStrategy ι U,
+      ∀ s : GameTree ι U, Subtree s g →
+        _root_.IsNashEquilibrium (toStrategicGame s) σ) ↔
+      ∃ τ : Strategy ι U,
+        ∀ s : GameTree ι U, Subtree s g → IsNashAt τ s := by
+  constructor
+  · rintro ⟨σ, hnash⟩
+    exact ⟨profileStrategy σ,
+      fun s hsub => (toStrategicGame_nash_iff_isNashAt s σ).mp (hnash s hsub)⟩
+  · rintro ⟨τ, hnash⟩
+    refine ⟨fun _ : ι => (τ : PlayerStrategy ι U), ?_⟩
+    intro s hsub
+    exact (toStrategicGame_nash_iff_isNashAt s _).mpr (by
+      simpa using hnash s hsub)
+
+/-- Existence of one normal-form profile that is pure Nash in every extracted
+    proper-subgame game is equivalent to existence of one tree strategy that is
+    root-scoped Nash at every proper subgame. -/
+theorem exists_forall_properSubgame_toStrategicGame_nash_iff_exists_forall_properSubgame_isNashAt
+    (g : GameTree ι U) :
+    (∃ σ : ι → PlayerStrategy ι U,
+      ∀ s : GameTree ι U, ProperSubgame s g →
+        _root_.IsNashEquilibrium (toStrategicGame s) σ) ↔
+      ∃ τ : Strategy ι U,
+        ∀ s : GameTree ι U, ProperSubgame s g → IsNashAt τ s := by
+  constructor
+  · rintro ⟨σ, hnash⟩
+    exact ⟨profileStrategy σ,
+      fun s hproper =>
+        (toStrategicGame_nash_iff_isNashAt s σ).mp (hnash s hproper)⟩
+  · rintro ⟨τ, hnash⟩
+    refine ⟨fun _ : ι => (τ : PlayerStrategy ι U), ?_⟩
+    intro s hproper
+    exact (toStrategicGame_nash_iff_isNashAt s _).mpr (by
+      simpa using hnash s hproper)
+
+/-- Existence of one normal-form profile that is pure Nash in every extracted
+    subtree game is equivalent to existence of a root-scoped subgame-perfect
+    tree strategy at the original root. -/
+theorem exists_forall_subtree_toStrategicGame_nash_iff_exists_isSubgamePerfectOn
+    (g : GameTree ι U) :
+    (∃ σ : ι → PlayerStrategy ι U,
+      ∀ s : GameTree ι U, Subtree s g →
+        _root_.IsNashEquilibrium (toStrategicGame s) σ) ↔
+      ∃ τ : Strategy ι U, IsSubgamePerfectOn τ g := by
+  rw [exists_forall_subtree_toStrategicGame_nash_iff_exists_forall_subtree_isNashAt]
+  constructor
+  · rintro ⟨τ, hnash⟩
+    exact ⟨τ, IsNashAt.toSubgamePerfectOn_of_forall_subtree_isNashAt hnash⟩
+  · rintro ⟨τ, hspe⟩
+    exact ⟨τ, hspe.forall_subtree_isNashAt⟩
+
+/-- Existence of a root Nash equilibrium together with pure Nash equilibrium in
+    every extracted proper-subgame game is equivalent to existence of a
+    root-scoped subgame-perfect tree strategy. -/
+theorem exists_toStrategicGame_nash_and_forall_properSubgame_toStrategicGame_nash_iff_exists_isSubgamePerfectOn
+    (g : GameTree ι U) :
+    (∃ σ : ι → PlayerStrategy ι U,
+      _root_.IsNashEquilibrium (toStrategicGame g) σ ∧
+        ∀ s : GameTree ι U, ProperSubgame s g →
+          _root_.IsNashEquilibrium (toStrategicGame s) σ) ↔
+      ∃ τ : Strategy ι U, IsSubgamePerfectOn τ g := by
+  constructor
+  · rintro ⟨σ, hnash, hproper⟩
+    refine ⟨profileStrategy σ, ?_⟩
+    exact IsNashAt.toSubgamePerfectOn_of_forall_properSubgame_isNashAt
+      ((toStrategicGame_nash_iff_isNashAt g σ).mp hnash)
+      (fun s hs => (toStrategicGame_nash_iff_isNashAt s σ).mp (hproper s hs))
+  · rintro ⟨τ, hspe⟩
+    refine ⟨fun _ : ι => (τ : PlayerStrategy ι U), ?_, ?_⟩
+    · exact (toStrategicGame_nash_iff_isNashAt g _).mpr (by
+        simpa using hspe.toNashAt)
+    · intro s hs
+      exact (toStrategicGame_nash_iff_isNashAt s _).mpr (by
+        simpa using hspe.toNashAt_of_properSubgame hs)
+
+/-- Existence of a root Nash equilibrium in the extracted strategic-form game
+    together with root-scoped SPE on every proper subgame is equivalent to
+    existence of a root-scoped subgame-perfect tree strategy. -/
+theorem exists_toStrategicGame_nash_and_forall_properSubgame_isSubgamePerfectOn_iff_exists_isSubgamePerfectOn
+    (g : GameTree ι U) :
+    (∃ σ : ι → PlayerStrategy ι U,
+      _root_.IsNashEquilibrium (toStrategicGame g) σ ∧
+        ∀ s : GameTree ι U, ProperSubgame s g →
+          IsSubgamePerfectOn (profileStrategy σ) s) ↔
+      ∃ τ : Strategy ι U, IsSubgamePerfectOn τ g := by
+  constructor
+  · rintro ⟨σ, hnash, hproper⟩
+    exact ⟨profileStrategy σ,
+      IsNashAt.toSubgamePerfectOn_of_forall_properSubgame_isSubgamePerfectOn
+        ((toStrategicGame_nash_iff_isNashAt g σ).mp hnash) hproper⟩
+  · rintro ⟨τ, hspe⟩
+    refine ⟨fun _ : ι => (τ : PlayerStrategy ι U), ?_, ?_⟩
+    · exact (toStrategicGame_nash_iff_isNashAt g _).mpr (by
+        simpa using hspe.toNashAt)
+    · intro s hs
+      simpa using hspe.of_properSubgame hs
+
+/-- Pure Nash equilibrium in the extracted strategic-form game of every
+    subtree gives root-scoped subgame perfection. -/
+theorem toSubgamePerfectOn_of_forall_subtree_toStrategicGame_nash
+    {g : GameTree ι U} {σ : ι → PlayerStrategy ι U}
+    (hnash : ∀ s : GameTree ι U, Subtree s g →
+      _root_.IsNashEquilibrium (toStrategicGame s) σ) :
+    IsSubgamePerfectOn (profileStrategy σ) g :=
+  IsNashAt.toSubgamePerfectOn_of_forall_subtree_isNashAt
+    (fun s hsub => (toStrategicGame_nash_iff_isNashAt s σ).mp (hnash s hsub))
+
+/-- Pure Nash equilibrium in the extracted strategic-form game of the root and
+    every proper subgame gives root-scoped subgame perfection. -/
+theorem toSubgamePerfectOn_of_toStrategicGame_nash_and_forall_properSubgame_toStrategicGame_nash
+    {g : GameTree ι U} {σ : ι → PlayerStrategy ι U}
+    (hnash : _root_.IsNashEquilibrium (toStrategicGame g) σ)
+    (hproper : ∀ s : GameTree ι U, ProperSubgame s g →
+      _root_.IsNashEquilibrium (toStrategicGame s) σ) :
+    IsSubgamePerfectOn (profileStrategy σ) g :=
+  IsNashAt.toSubgamePerfectOn_of_forall_properSubgame_isNashAt
+    ((toStrategicGame_nash_iff_isNashAt g σ).mp hnash)
+    (fun s hs => (toStrategicGame_nash_iff_isNashAt s σ).mp (hproper s hs))
+
+/-- Pure Nash equilibrium in the extracted strategic-form root game, together
+    with root-scoped subgame perfection on every proper subgame, gives
+    root-scoped subgame perfection. -/
+theorem toSubgamePerfectOn_of_toStrategicGame_nash_and_forall_properSubgame_isSubgamePerfectOn
+    {g : GameTree ι U} {σ : ι → PlayerStrategy ι U}
+    (hnash : _root_.IsNashEquilibrium (toStrategicGame g) σ)
+    (hproper : ∀ s : GameTree ι U, ProperSubgame s g →
+      IsSubgamePerfectOn (profileStrategy σ) s) :
+    IsSubgamePerfectOn (profileStrategy σ) g :=
+  IsNashAt.toSubgamePerfectOn_of_forall_properSubgame_isSubgamePerfectOn
+    ((toStrategicGame_nash_iff_isNashAt g σ).mp hnash) hproper
+
+/-- Root-scoped subgame perfection is equivalent to pure Nash equilibrium in
+    the extracted strategic-form game of every subtree. -/
+theorem isSubgamePerfectOn_iff_forall_subtree_toStrategicGame_nash
+    {g : GameTree ι U} (σ : (toStrategicGame g).Profile) :
+    IsSubgamePerfectOn (profileStrategy σ) g ↔
+      ∀ s : GameTree ι U, Subtree s g →
+        _root_.IsNashEquilibrium (toStrategicGame s) σ := by
+  constructor
+  · intro hspe
+    exact hspe.forall_subtree_toStrategicGame_nash
+  · intro hnash
+    exact toSubgamePerfectOn_of_forall_subtree_toStrategicGame_nash hnash
+
+/-- Root-scoped subgame perfection is equivalent to pure Nash equilibrium in
+    the extracted strategic-form game at the root and at every proper subgame. -/
+theorem isSubgamePerfectOn_iff_toStrategicGame_nash_and_forall_properSubgame_toStrategicGame_nash
+    {g : GameTree ι U} (σ : (toStrategicGame g).Profile) :
+    IsSubgamePerfectOn (profileStrategy σ) g ↔
+      _root_.IsNashEquilibrium (toStrategicGame g) σ ∧
+        ∀ s : GameTree ι U, ProperSubgame s g →
+          _root_.IsNashEquilibrium (toStrategicGame s) σ := by
+  constructor
+  · intro hspe
+    exact ⟨hspe.toStrategicGame_nash,
+      hspe.forall_properSubgame_toStrategicGame_nash⟩
+  · rintro ⟨hnash, hproper⟩
+    exact
+      toSubgamePerfectOn_of_toStrategicGame_nash_and_forall_properSubgame_toStrategicGame_nash
+        hnash hproper
+
+/-- Root-scoped subgame perfection is equivalent to pure Nash equilibrium in
+    the extracted strategic-form game at the root, together with root-scoped
+    subgame perfection on every proper subgame. -/
+theorem isSubgamePerfectOn_iff_toStrategicGame_nash_and_forall_properSubgame_isSubgamePerfectOn
+    {g : GameTree ι U} (σ : (toStrategicGame g).Profile) :
+    IsSubgamePerfectOn (profileStrategy σ) g ↔
+      _root_.IsNashEquilibrium (toStrategicGame g) σ ∧
+        ∀ s : GameTree ι U, ProperSubgame s g →
+          IsSubgamePerfectOn (profileStrategy σ) s := by
+  constructor
+  · intro hspe
+    exact hspe.toStrategicGame_nash_and_forall_properSubgame_isSubgamePerfectOn
+  · rintro ⟨hnash, hproper⟩
+    exact
+      toSubgamePerfectOn_of_toStrategicGame_nash_and_forall_properSubgame_isSubgamePerfectOn
+        hnash hproper
+
+/-- Root-scoped subgame perfection at a nonterminal node can be checked by
+    pure Nash equilibrium in the extracted strategic-form game of the node,
+    plus root-scoped subgame perfection on the head child and every tail
+    child. -/
+theorem isSubgamePerfectOn_Node_iff_toStrategicGame_nash_and_head_tail
+    {σ : ι → PlayerStrategy ι U}
+    {m : ι} {h : GameTree ι U} {t : List (GameTree ι U)} :
+    IsSubgamePerfectOn (profileStrategy σ) (Node m h t) ↔
+      _root_.IsNashEquilibrium (toStrategicGame (Node m h t)) σ ∧
+        IsSubgamePerfectOn (profileStrategy σ) h ∧
+          ∀ c ∈ t, IsSubgamePerfectOn (profileStrategy σ) c := by
+  rw [isSubgamePerfectOn_Node_iff]
+  constructor
+  · rintro ⟨hnash, hhead, htail⟩
+    exact ⟨(toStrategicGame_nash_iff_isNashAt (Node m h t) σ).mpr hnash,
+      hhead, htail⟩
+  · rintro ⟨hnash, hhead, htail⟩
+    exact ⟨(toStrategicGame_nash_iff_isNashAt (Node m h t) σ).mp hnash,
+      hhead, htail⟩
+
+/-- Root-scoped subgame perfection at a nonterminal node gives pure Nash in the
+    extracted strategic-form game of the node, together with root-scoped
+    subgame perfection on the head child and every tail child. -/
+theorem IsSubgamePerfectOn.toStrategicGame_nash_and_head_tail
+    {σ : ι → PlayerStrategy ι U}
+    {m : ι} {h : GameTree ι U} {t : List (GameTree ι U)}
+    (hspe : IsSubgamePerfectOn (profileStrategy σ) (Node m h t)) :
+    _root_.IsNashEquilibrium (toStrategicGame (Node m h t)) σ ∧
+      IsSubgamePerfectOn (profileStrategy σ) h ∧
+        ∀ c ∈ t, IsSubgamePerfectOn (profileStrategy σ) c :=
+  (isSubgamePerfectOn_Node_iff_toStrategicGame_nash_and_head_tail).mp hspe
+
+/-- Root-scoped subgame perfection at a nonterminal node can be checked by
+    pure Nash equilibrium in the extracted strategic-form game of the node,
+    plus root-scoped subgame perfection on every direct child. -/
+theorem isSubgamePerfectOn_Node_iff_toStrategicGame_nash_and_children
+    {σ : ι → PlayerStrategy ι U}
+    {m : ι} {h : GameTree ι U} {t : List (GameTree ι U)} :
+    IsSubgamePerfectOn (profileStrategy σ) (Node m h t) ↔
+      _root_.IsNashEquilibrium (toStrategicGame (Node m h t)) σ ∧
+        ∀ c ∈ children (Node m h t), IsSubgamePerfectOn (profileStrategy σ) c := by
+  rw [isSubgamePerfectOn_Node_iff_children]
+  constructor
+  · rintro ⟨hnash, hchildren⟩
+    exact ⟨(toStrategicGame_nash_iff_isNashAt (Node m h t) σ).mpr hnash,
+      hchildren⟩
+  · rintro ⟨hnash, hchildren⟩
+    exact ⟨(toStrategicGame_nash_iff_isNashAt (Node m h t) σ).mp hnash,
+      hchildren⟩
+
+/-- Root-scoped subgame perfection at a nonterminal node gives pure Nash in the
+    extracted strategic-form game of the node, together with root-scoped
+    subgame perfection on every child in the public `children` list. -/
+theorem IsSubgamePerfectOn.toStrategicGame_nash_and_children
+    {σ : ι → PlayerStrategy ι U}
+    {m : ι} {h : GameTree ι U} {t : List (GameTree ι U)}
+    (hspe : IsSubgamePerfectOn (profileStrategy σ) (Node m h t)) :
+    _root_.IsNashEquilibrium (toStrategicGame (Node m h t)) σ ∧
+      ∀ c ∈ children (Node m h t), IsSubgamePerfectOn (profileStrategy σ) c :=
+  (isSubgamePerfectOn_Node_iff_toStrategicGame_nash_and_children).mp hspe
+
+/-- Pure Nash equilibrium in the extracted strategic-form game of a
+    nonterminal node, together with root-scoped subgame perfection on every
+    direct child, gives root-scoped subgame perfection at the node. -/
+theorem toStrategicGame_nash_toSubgamePerfectOn_Node_of_children
+    {σ : ι → PlayerStrategy ι U}
+    {m : ι} {h : GameTree ι U} {t : List (GameTree ι U)}
+    (hnash : _root_.IsNashEquilibrium (toStrategicGame (Node m h t)) σ)
+    (hchildren :
+      ∀ c ∈ children (Node m h t), IsSubgamePerfectOn (profileStrategy σ) c) :
+    IsSubgamePerfectOn (profileStrategy σ) (Node m h t) :=
+  (isSubgamePerfectOn_Node_iff_toStrategicGame_nash_and_children).mpr
+    ⟨hnash, hchildren⟩
+
+/-- Pure Nash equilibrium in the extracted strategic-form game of a
+    nonterminal node, together with root-scoped subgame perfection on the head
+    child and every tail child, gives root-scoped subgame perfection at the
+    node. -/
+theorem toStrategicGame_nash_toSubgamePerfectOn_Node
+    {σ : ι → PlayerStrategy ι U}
+    {m : ι} {h : GameTree ι U} {t : List (GameTree ι U)}
+    (hnash : _root_.IsNashEquilibrium (toStrategicGame (Node m h t)) σ)
+    (hhead : IsSubgamePerfectOn (profileStrategy σ) h)
+    (htail : ∀ c ∈ t, IsSubgamePerfectOn (profileStrategy σ) c) :
+    IsSubgamePerfectOn (profileStrategy σ) (Node m h t) :=
+  (isSubgamePerfectOn_Node_iff_toStrategicGame_nash_and_head_tail).mpr
+    ⟨hnash, hhead, htail⟩
+
+/-- Existence of one normal-form profile satisfying the strategic-form root
+    Nash and head/tail SPE check at a node is equivalent to existence of a
+    root-scoped SPE tree strategy at that node. -/
+theorem exists_toStrategicGame_nash_and_child_isSubgamePerfectOn_iff_exists_isSubgamePerfectOn_Node
+    (m : ι) (h : GameTree ι U) (t : List (GameTree ι U)) :
+    (∃ σ : ι → PlayerStrategy ι U,
+      _root_.IsNashEquilibrium (toStrategicGame (Node m h t)) σ ∧
+        IsSubgamePerfectOn (profileStrategy σ) h ∧
+          ∀ c ∈ t, IsSubgamePerfectOn (profileStrategy σ) c) ↔
+      ∃ τ : Strategy ι U, IsSubgamePerfectOn τ (Node m h t) := by
+  constructor
+  · rintro ⟨σ, hnash, hhead, htail⟩
+    exact ⟨profileStrategy σ,
+      toStrategicGame_nash_toSubgamePerfectOn_Node hnash hhead htail⟩
+  · rintro ⟨τ, hspe⟩
+    refine ⟨fun _ : ι => (τ : PlayerStrategy ι U), ?_, ?_, ?_⟩
+    · exact (toStrategicGame_nash_iff_isNashAt (Node m h t) _).mpr (by
+        simpa using hspe.toNashAt)
+    · simpa using hspe.head
+    · intro c hmem
+      simpa using hspe.tail_mem hmem
+
+/-- Existence of one normal-form profile satisfying the strategic-form root
+    Nash and children SPE check at a node is equivalent to existence of a
+    root-scoped SPE tree strategy at that node. -/
+theorem exists_toStrategicGame_nash_and_children_isSubgamePerfectOn_iff_exists_isSubgamePerfectOn_Node
+    (m : ι) (h : GameTree ι U) (t : List (GameTree ι U)) :
+    (∃ σ : ι → PlayerStrategy ι U,
+      _root_.IsNashEquilibrium (toStrategicGame (Node m h t)) σ ∧
+        ∀ c ∈ children (Node m h t), IsSubgamePerfectOn (profileStrategy σ) c) ↔
+      ∃ τ : Strategy ι U, IsSubgamePerfectOn τ (Node m h t) := by
+  constructor
+  · rintro ⟨σ, hnash, hchildren⟩
+    exact ⟨profileStrategy σ,
+      toStrategicGame_nash_toSubgamePerfectOn_Node_of_children hnash hchildren⟩
+  · rintro ⟨τ, hspe⟩
+    refine ⟨fun _ : ι => (τ : PlayerStrategy ι U), ?_, ?_⟩
+    · exact (toStrategicGame_nash_iff_isNashAt (Node m h t) _).mpr (by
+        simpa using hspe.toNashAt)
+    · intro c hc
+      simpa using hspe.child hc
+
+/-- The backward-induction normal-form profile is a pure Nash equilibrium of
+    the extracted strategic-form game. -/
+theorem optStrategyProfile_toStrategicGame_nash (g : GameTree ι U) :
+    _root_.IsNashEquilibrium (toStrategicGame g)
+      (optStrategyProfile : (toStrategicGame g).Profile) :=
+  (toStrategicGame_nash_iff_isNashAt g optStrategyProfile).mpr (by
+    simpa using optStrategy_isNashAt (g := g))
+
+/-- The backward-induction normal-form profile is pure Nash in the extracted
+    strategic-form game of every subtree of a fixed root. -/
+theorem optStrategyProfile_toStrategicGame_nash_on_subtree {s g : GameTree ι U}
+    (hsub : Subtree s g) :
+    _root_.IsNashEquilibrium (toStrategicGame s)
+      (optStrategyProfile : (toStrategicGame s).Profile) :=
+  (toStrategicGame_nash_iff_isNashAt s optStrategyProfile).mpr
+    (optStrategy_isNashAt_subtree hsub)
+
+/-- The backward-induction normal-form profile is pure Nash in the extracted
+    strategic-form game of every proper subgame of a fixed root. -/
+theorem optStrategyProfile_toStrategicGame_nash_on_properSubgame
+    {s g : GameTree ι U} (hproper : ProperSubgame s g) :
+    _root_.IsNashEquilibrium (toStrategicGame s)
+      (optStrategyProfile : (toStrategicGame s).Profile) :=
+  (toStrategicGame_nash_iff_isNashAt s optStrategyProfile).mpr
+    (optStrategy_isNashAt_properSubgame hproper)
+
+/-- Kuhn/backward induction gives a pure Nash equilibrium of the extracted
+    strategic-form game. -/
+theorem Kuhn_exists_toStrategicGame_nash (g : GameTree ι U) :
+    ∃ σ : (toStrategicGame g).Profile,
+      _root_.IsNashEquilibrium (toStrategicGame g) σ := by
+  exact ⟨optStrategyProfile, optStrategyProfile_toStrategicGame_nash g⟩
+
+/-- Kuhn/backward induction gives one pure normal-form profile that is Nash in
+    the extracted strategic-form game of every subtree of a fixed root. -/
+theorem Kuhn_exists_toStrategicGame_nash_on_subtrees (g : GameTree ι U) :
+    ∃ σ : ι → PlayerStrategy ι U,
+      ∀ s : GameTree ι U, Subtree s g →
+        _root_.IsNashEquilibrium (toStrategicGame s) σ := by
+  exact ⟨optStrategyProfile,
+    fun _ hsub => optStrategyProfile_toStrategicGame_nash_on_subtree hsub⟩
+
+/-- Kuhn/backward induction gives one pure normal-form profile that is Nash in
+    the extracted strategic-form game of every proper subgame of a fixed root. -/
+theorem Kuhn_exists_toStrategicGame_nash_on_properSubgames (g : GameTree ι U) :
+    ∃ σ : ι → PlayerStrategy ι U,
+      ∀ s : GameTree ι U, ProperSubgame s g →
+        _root_.IsNashEquilibrium (toStrategicGame s) σ := by
+  exact ⟨optStrategyProfile,
+    fun _ hproper => optStrategyProfile_toStrategicGame_nash_on_properSubgame hproper⟩
+
+/-- Kuhn/backward induction gives one pure normal-form profile that is Nash in
+    the extracted strategic-form game of the root and of every proper subgame. -/
+theorem Kuhn_exists_toStrategicGame_nash_and_toStrategicGame_nash_on_properSubgames
+    (g : GameTree ι U) :
+    ∃ σ : ι → PlayerStrategy ι U,
+      _root_.IsNashEquilibrium (toStrategicGame g) σ ∧
+        ∀ s : GameTree ι U, ProperSubgame s g →
+          _root_.IsNashEquilibrium (toStrategicGame s) σ := by
+  exact ⟨optStrategyProfile,
+    optStrategyProfile_toStrategicGame_nash g,
+    fun _ hproper => optStrategyProfile_toStrategicGame_nash_on_properSubgame hproper⟩
+
+/-- Kuhn/backward induction gives one pure normal-form profile that is Nash in
+    the extracted strategic-form game of the root and whose induced tree
+    strategy is subgame-perfect on every proper subgame. -/
+theorem Kuhn_exists_toStrategicGame_nash_and_SPE_on_properSubgames
+    (g : GameTree ι U) :
+    ∃ σ : ι → PlayerStrategy ι U,
+      _root_.IsNashEquilibrium (toStrategicGame g) σ ∧
+        ∀ s : GameTree ι U, ProperSubgame s g →
+          IsSubgamePerfectOn (profileStrategy σ) s := by
+  exact ⟨optStrategyProfile,
+    optStrategyProfile_toStrategicGame_nash g,
+    fun _ hproper => by
+      simpa using optStrategy_isSubgamePerfectOn_properSubgame hproper⟩
+
+/-- Kuhn/backward induction gives one pure normal-form profile that is Nash in
+    every extracted strategic-form game. -/
+theorem Kuhn_exists_forall_toStrategicGame_nash :
+    ∃ σ : ι → PlayerStrategy ι U,
+      ∀ g : GameTree ι U, _root_.IsNashEquilibrium (toStrategicGame g) σ := by
+  exact ⟨optStrategyProfile, fun g => optStrategyProfile_toStrategicGame_nash g⟩
 
 end GameTree

--- a/EconCSLib/GameTheory/ExtensiveGame/GameTreeStrategicForm.lean
+++ b/EconCSLib/GameTheory/ExtensiveGame/GameTreeStrategicForm.lean
@@ -99,13 +99,14 @@ theorem profileStrategy_surjective :
 /-- The normal-form profile induced by the canonical backward-induction
     strategy. Each player is assigned the same complete contingent plan
     `optStrategy`; at a node, `profileStrategy` then reads the mover's plan. -/
-noncomputable def optStrategyProfile [TotalPreorder U] : ι → PlayerStrategy ι U :=
+noncomputable def optStrategyProfile [TotalPreorder U] [DecidableLE U] :
+    ι → PlayerStrategy ι U :=
   fun _ => (optStrategy : PlayerStrategy ι U)
 
 /-- Evaluating the backward-induction normal-form profile recovers the
     canonical backward-induction tree strategy. -/
 @[simp]
-theorem profileStrategy_optStrategyProfile [TotalPreorder U] :
+theorem profileStrategy_optStrategyProfile [TotalPreorder U] [DecidableLE U] :
     profileStrategy (optStrategyProfile : ι → PlayerStrategy ι U) =
       (optStrategy : Strategy ι U) :=
   rfl
@@ -221,7 +222,7 @@ theorem IsSubgamePerfectOn.exists_toStrategicGame_nash_of_properSubgame
 
 /-- The extracted strategic-form game of a terminal leaf has a pure Nash
     equilibrium. -/
-theorem exists_toStrategicGame_nash_Leaf (p : ι → U) :
+theorem exists_toStrategicGame_nash_Leaf [DecidableLE U] (p : ι → U) :
     ∃ σ : (toStrategicGame (Leaf p : GameTree ι U)).Profile,
       _root_.IsNashEquilibrium (toStrategicGame (Leaf p : GameTree ι U)) σ :=
   (isNashAt_Leaf (optStrategy : Strategy ι U) p).exists_toStrategicGame_nash
@@ -790,6 +791,8 @@ theorem exists_toStrategicGame_nash_and_children_isSubgamePerfectOn_iff_exists_i
         simpa using hspe.toNashAt)
     · intro c hc
       simpa using hspe.child hc
+
+variable [DecidableLE U]
 
 /-- The backward-induction normal-form profile is a pure Nash equilibrium of
     the extracted strategic-form game. -/

--- a/EconCSLib/GameTheory/ExtensiveGame/ImperfectInformation.lean
+++ b/EconCSLib/GameTheory/ExtensiveGame/ImperfectInformation.lean
@@ -4,11 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 
 import Mathlib.Data.Fintype.Basic
+import Mathlib.Analysis.Convex.StdSimplex
 import Mathlib.Logic.Function.Basic
 import Mathlib.Tactic.FinCases
+import Mathlib.Tactic.NormNum
 
 /-!
-# EconCSLib.GameTheory.ExtensiveGame.ImperfectInformation
+# ExtensiveGame.ImperfectInformation
 
 A finite interface for imperfect-information extensive games.
 
@@ -22,11 +24,18 @@ the conditions they need.
 
 * `FiniteImperfectGame` — finite imperfect-information extensive game data.
 * `FiniteImperfectGame.subgameAt` — the same game rooted at a chosen state.
+* `FiniteImperfectGame.Reachable` / `FiniteImperfectGame.IsReachable` —
+  path reachability in the finite state graph.
 * `SameMoverOnInfo` — nodes in one information set have the same mover.
 * `SameActionsOnInfo` — nodes in one information set have the same action type.
 * `NoChanceOnDecisionInfo` — information sets are only used at player nodes.
 * `PureStrategy` — choices indexed by player and information set.
 * `PureStrategy.actionAt` — induced action at a concrete state.
+* `PureStrategy.restrictToSubgame` / `BehaviorStrategy.restrictToSubgame` —
+  strategy restriction to a re-rooted subgame.
+* `BehaviorStrategy` — a mixed action at each information-set query.
+* `IsCompletelyMixedBehaviorStrategy` / `IsCompletelyMixedBehaviorProfile` —
+  every available action has positive probability.
 -/
 
 /-- Finite imperfect-information extensive game data.
@@ -34,7 +43,7 @@ the conditions they need.
 `info s = none` means the state is not in a strategic information set, typically
 because it is terminal or chance-controlled.  `info s = some k` places state `s`
 in information set `k`. -/
-structure FiniteImperfectGame (N U : Type*) where
+structure FiniteImperfectGame (ι U : Type*) where
   State : Type*
   [stateFintype : Fintype State]
   [stateDecidableEq : DecidableEq State]
@@ -43,9 +52,9 @@ structure FiniteImperfectGame (N U : Type*) where
   Action : State → Type*
   next : (s : State) → Action s → State
   init : State
-  mover : State → Option N
+  mover : State → Option ι
   info : State → Option InfoSet
-  payoff : State → N → U
+  payoff : State → ι → U
 
 attribute [instance] FiniteImperfectGame.stateFintype
 attribute [instance] FiniteImperfectGame.stateDecidableEq
@@ -53,7 +62,7 @@ attribute [instance] FiniteImperfectGame.infoDecidableEq
 
 namespace FiniteImperfectGame
 
-variable {N U : Type*} (G : FiniteImperfectGame N U)
+variable {ι U : Type*} (G : FiniteImperfectGame ι U)
 
 /-- A state is terminal when it has no available actions. -/
 def IsTerminal (s : G.State) : Prop := IsEmpty (G.Action s)
@@ -62,11 +71,73 @@ def IsTerminal (s : G.State) : Prop := IsEmpty (G.Action s)
 initial state.  Extra validity conditions, such as whether `s` is a legitimate
 imperfect-information subroot, can be imposed by theorem statements using this
 operation. -/
-def subgameAt (s : G.State) : FiniteImperfectGame N U :=
+def subgameAt (s : G.State) : FiniteImperfectGame ι U :=
   { G with init := s }
 
 /-- The initial state of `subgameAt` is the chosen root. -/
 theorem subgameAt_init (s : G.State) : (G.subgameAt s).init = s := rfl
+
+/-- Re-rooting does not change the available actions at a state. -/
+theorem subgameAt_action (root s : G.State) :
+    (G.subgameAt root).Action s = G.Action s := rfl
+
+/-- Re-rooting does not change the transition function. -/
+theorem subgameAt_next (root s : G.State) (a : G.Action s) :
+    (G.subgameAt root).next s a = G.next s a := rfl
+
+/-- Re-rooting does not change the mover at a state. -/
+theorem subgameAt_mover (root s : G.State) :
+    (G.subgameAt root).mover s = G.mover s := rfl
+
+/-- Re-rooting does not change information-set labels. -/
+theorem subgameAt_info (root s : G.State) :
+    (G.subgameAt root).info s = G.info s := rfl
+
+/-- Re-rooting does not change payoff labels. -/
+theorem subgameAt_payoff (root s : G.State) (i : ι) :
+    (G.subgameAt root).payoff s i = G.payoff s i := rfl
+
+/-! ### Reachability -/
+
+/-- `Reachable s t` means that `t` can be reached from `s` by following zero or
+more actions in the finite game graph. -/
+inductive Reachable : G.State → G.State → Prop where
+  | refl (s : G.State) : Reachable s s
+  | step {s t : G.State} (a : G.Action s) (h : Reachable (G.next s a) t) :
+      Reachable s t
+
+/-- Reachability is transitive. -/
+theorem Reachable.trans {s t u : G.State}
+    (h1 : G.Reachable s t) (h2 : G.Reachable t u) :
+    G.Reachable s u := by
+  induction h1 with
+  | refl => exact h2
+  | step a _ ih => exact Reachable.step a (ih h2)
+
+/-- One transition extends reachability. -/
+theorem Reachable.step' {s t : G.State}
+    (h : G.Reachable s t) (a : G.Action t) :
+    G.Reachable s (G.next t a) :=
+  Reachable.trans G h (Reachable.step a (Reachable.refl (G := G) _))
+
+/-- A state is reachable in the game if it is reachable from the initial state. -/
+def IsReachable (s : G.State) : Prop :=
+  G.Reachable G.init s
+
+/-- The initial state is reachable. -/
+theorem isReachable_init : G.IsReachable G.init :=
+  Reachable.refl _
+
+/-- Taking one action from a reachable state reaches the successor state. -/
+theorem IsReachable.next {s : G.State}
+    (h : G.IsReachable s) (a : G.Action s) :
+    G.IsReachable (G.next s a) :=
+  Reachable.step' G h a
+
+/-- The chosen root is reachable in its re-rooted subgame. -/
+theorem subgameAt_isReachable_root (root : G.State) :
+    (G.subgameAt root).IsReachable root :=
+  isReachable_init (G := G.subgameAt root)
 
 /-- States in the same information set have the same mover. -/
 def SameMoverOnInfo : Prop :=
@@ -80,34 +151,55 @@ def SameActionsOnInfo : Prop :=
 
 /-- Strategic information sets are attached only to player-controlled states. -/
 def NoChanceOnDecisionInfo : Prop :=
-  ∀ {s : G.State} {k : G.InfoSet}, G.info s = some k → ∃ i : N, G.mover s = some i
+  ∀ {s : G.State} {k : G.InfoSet}, G.info s = some k → ∃ i : ι, G.mover s = some i
 
 /-- Basic well-formedness package for information-set reasoning. -/
 def InfoWellFormed : Prop :=
   G.SameMoverOnInfo ∧ G.SameActionsOnInfo ∧ G.NoChanceOnDecisionInfo
 
+/-- Re-rooting preserves the same-mover-on-information-set condition. -/
+theorem subgameAt_sameMoverOnInfo {s : G.State} (h : G.SameMoverOnInfo) :
+    (G.subgameAt s).SameMoverOnInfo := by
+  intro t u k ht hu
+  exact h (by simpa [subgameAt] using ht) (by simpa [subgameAt] using hu)
+
+/-- Re-rooting preserves the same-action-types-on-information-set condition. -/
+theorem subgameAt_sameActionsOnInfo {s : G.State} (h : G.SameActionsOnInfo) :
+    (G.subgameAt s).SameActionsOnInfo := by
+  intro t u k ht hu
+  exact h (by simpa [subgameAt] using ht) (by simpa [subgameAt] using hu)
+
+/-- Re-rooting preserves the condition that strategic information sets are not
+    chance nodes. -/
+theorem subgameAt_noChanceOnDecisionInfo {s : G.State}
+    (h : G.NoChanceOnDecisionInfo) :
+    (G.subgameAt s).NoChanceOnDecisionInfo := by
+  intro t k ht
+  exact h (by simpa [subgameAt] using ht)
+
 /-- Re-rooting a finite imperfect-information game preserves the local
 information-set well-formedness package. -/
 theorem subgameAt_infoWellFormed {s : G.State} (h : G.InfoWellFormed) :
     (G.subgameAt s).InfoWellFormed := by
-  simpa [subgameAt, InfoWellFormed, SameMoverOnInfo, SameActionsOnInfo,
-    NoChanceOnDecisionInfo] using h
+  exact ⟨G.subgameAt_sameMoverOnInfo h.1,
+    G.subgameAt_sameActionsOnInfo h.2.1,
+    G.subgameAt_noChanceOnDecisionInfo h.2.2⟩
 
 /-- A pure strategy chooses one abstract action for each player and information set.
 
 The action type is indexed by a representative state for that information set.
 For a concrete state `s`, `actionAt` below specializes this choice at `s`, so
 choices are constant on information sets by construction at the API boundary. -/
-def PureStrategy (i : N) : Type _ :=
+def PureStrategy (i : ι) : Type _ :=
   (k : G.InfoSet) → (s : G.State) → G.info s = some k → G.mover s = some i → G.Action s
 
 /-- A pure strategy profile. -/
 def PureStrategyProfile : Type _ :=
-  (i : N) → G.PureStrategy i
+  (i : ι) → G.PureStrategy i
 
 /-- The action prescribed at a concrete player-controlled state in an
     information set. -/
-def PureStrategy.actionAt {i : N} (σ : G.PureStrategy i) {s : G.State}
+def PureStrategy.actionAt {i : ι} (σ : G.PureStrategy i) {s : G.State}
     {k : G.InfoSet} (hinfo : G.info s = some k) (hmover : G.mover s = some i) :
     G.Action s :=
   σ k s hinfo hmover
@@ -116,13 +208,223 @@ def PureStrategy.actionAt {i : N} (σ : G.PureStrategy i) {s : G.State}
     the same information-set label at both states.  This is the formal
     constancy-by-indexing property; comparing concrete action values requires
     an action equivalence from `SameActionsOnInfo`. -/
-theorem actionAt_same_info_label {i : N} (σ : G.PureStrategy i)
+theorem actionAt_same_info_label {i : ι} (σ : G.PureStrategy i)
     {s t : G.State} {k : G.InfoSet}
     (hs : G.info s = some k) (ht : G.info t = some k)
     (hms : G.mover s = some i) (hmt : G.mover t = some i) :
     PureStrategy.actionAt G σ hs hms = σ k s hs hms ∧
       PureStrategy.actionAt G σ ht hmt = σ k t ht hmt :=
   ⟨rfl, rfl⟩
+
+/-- Restrict a pure strategy to the subgame rooted at `root`.
+
+The state, action, mover, and information-set data are unchanged by
+`subgameAt`; only the initial state changes. -/
+def PureStrategy.restrictToSubgame {i : ι} (σ : G.PureStrategy i)
+    (root : G.State) : (G.subgameAt root).PureStrategy i :=
+  fun k s hinfo hmover =>
+    σ k s (by simpa [subgameAt] using hinfo) (by simpa [subgameAt] using hmover)
+
+/-- Restricting a pure strategy does not change the action prescribed at any
+    concrete information-set query. -/
+theorem PureStrategy.restrictToSubgame_actionAt {i : ι} (σ : G.PureStrategy i)
+    (root : G.State) {s : G.State} {k : G.InfoSet}
+    (hinfo : (G.subgameAt root).info s = some k)
+    (hmover : (G.subgameAt root).mover s = some i) :
+    PureStrategy.actionAt (G.subgameAt root)
+        (PureStrategy.restrictToSubgame G σ root) hinfo hmover =
+      PureStrategy.actionAt G σ
+        (by simpa [subgameAt] using hinfo)
+        (by simpa [subgameAt] using hmover) := by
+  simp [PureStrategy.actionAt, PureStrategy.restrictToSubgame]
+
+/-- Restrict a pure strategy profile to the subgame rooted at `root`. -/
+def PureStrategyProfile.restrictToSubgame (σ : G.PureStrategyProfile)
+    (root : G.State) : (G.subgameAt root).PureStrategyProfile :=
+  fun i => PureStrategy.restrictToSubgame G (σ i) root
+
+/-- Restricting a pure strategy profile does not change the action prescribed
+    by any player at any concrete information-set query. -/
+theorem PureStrategyProfile.restrictToSubgame_actionAt (σ : G.PureStrategyProfile)
+    (root : G.State) (i : ι) {s : G.State} {k : G.InfoSet}
+    (hinfo : (G.subgameAt root).info s = some k)
+    (hmover : (G.subgameAt root).mover s = some i) :
+    PureStrategy.actionAt (G.subgameAt root)
+        ((PureStrategyProfile.restrictToSubgame G σ root) i) hinfo hmover =
+      PureStrategy.actionAt G (σ i)
+        (by simpa [subgameAt] using hinfo)
+        (by simpa [subgameAt] using hmover) :=
+  PureStrategy.restrictToSubgame_actionAt (G := G) (σ i) root hinfo hmover
+
+/-! ### Behavior strategies -/
+
+/-- A behavior strategy for player `i`: at each information-set query, choose a
+    mixed action at the concrete state used for that query. This is a structural
+    behavior-strategy layer; equivalences between action types inside one
+    information set are supplied separately by `SameActionsOnInfo`. -/
+def BehaviorStrategy (i : ι) : Type _ :=
+  (k : G.InfoSet) → (s : G.State) → (hinfo : G.info s = some k) →
+    (hmover : G.mover s = some i) → [Fintype (G.Action s)] →
+      stdSimplex ℚ (G.Action s)
+
+/-- A behavior-strategy profile. -/
+def BehaviorProfile : Type _ :=
+  (i : ι) → G.BehaviorStrategy i
+
+/-- The mixed action prescribed at a concrete player-controlled state in an
+    information set. -/
+def BehaviorStrategy.mixedActionAt {i : ι} (β : G.BehaviorStrategy i)
+    {s : G.State} {k : G.InfoSet} (hinfo : G.info s = some k)
+    (hmover : G.mover s = some i) [Fintype (G.Action s)] :
+    stdSimplex ℚ (G.Action s) :=
+  β k s hinfo hmover
+
+/-- Restrict a behavior strategy to the subgame rooted at `root`.
+
+As for pure strategies, re-rooting changes only `init`, so the same local mixed
+actions are reused in the subgame. -/
+def BehaviorStrategy.restrictToSubgame {i : ι} (β : G.BehaviorStrategy i)
+    (root : G.State) : (G.subgameAt root).BehaviorStrategy i :=
+  fun k s hinfo hmover hfin => by
+    letI : Fintype (G.Action s) := hfin
+    exact β k s (by simpa [subgameAt] using hinfo)
+      (by simpa [subgameAt] using hmover)
+
+/-- Restricting a behavior strategy does not change the probability assigned
+    to any concrete action at an information-set query. -/
+theorem BehaviorStrategy.restrictToSubgame_mixedActionAt_apply {i : ι}
+    (β : G.BehaviorStrategy i) (root : G.State) {s : G.State} {k : G.InfoSet}
+    (hinfo : (G.subgameAt root).info s = some k)
+    (hmover : (G.subgameAt root).mover s = some i)
+    [Fintype (G.Action s)] (a : G.Action s) :
+    (@BehaviorStrategy.mixedActionAt ι U (G.subgameAt root) i
+        (BehaviorStrategy.restrictToSubgame G β root) s k hinfo hmover
+        (by simpa [subgameAt] using (inferInstance : Fintype (G.Action s)))).val
+        (by simpa [subgameAt] using a) =
+      (@BehaviorStrategy.mixedActionAt ι U G i β s k
+        (by simpa [subgameAt] using hinfo)
+        (by simpa [subgameAt] using hmover)
+        (inferInstance : Fintype (G.Action s))).val a := by
+  rfl
+
+/-- Restrict a behavior-strategy profile to the subgame rooted at `root`. -/
+def BehaviorProfile.restrictToSubgame (β : G.BehaviorProfile)
+    (root : G.State) : (G.subgameAt root).BehaviorProfile :=
+  fun i => BehaviorStrategy.restrictToSubgame G (β i) root
+
+/-- Restricting a behavior profile does not change the probability assigned by
+    any player to any concrete action at an information-set query. -/
+theorem BehaviorProfile.restrictToSubgame_mixedActionAt_apply
+    (β : G.BehaviorProfile) (root : G.State) (i : ι)
+    {s : G.State} {k : G.InfoSet}
+    (hinfo : (G.subgameAt root).info s = some k)
+    (hmover : (G.subgameAt root).mover s = some i)
+    [Fintype (G.Action s)] (a : G.Action s) :
+    (@BehaviorStrategy.mixedActionAt ι U (G.subgameAt root) i
+        ((BehaviorProfile.restrictToSubgame G β root) i) s k hinfo hmover
+        (by simpa [subgameAt] using (inferInstance : Fintype (G.Action s)))).val
+        (by simpa [subgameAt] using a) =
+      (@BehaviorStrategy.mixedActionAt ι U G i (β i) s k
+        (by simpa [subgameAt] using hinfo)
+        (by simpa [subgameAt] using hmover)
+        (inferInstance : Fintype (G.Action s))).val a :=
+  BehaviorStrategy.restrictToSubgame_mixedActionAt_apply
+    (G := G) (β := β i) root hinfo hmover a
+
+/-- A behavior strategy is completely mixed at every information-set query if
+    every available action at that query has positive probability. This is the
+    behavior-strategy part of MSZ Definition 7.6 at the structural API level. -/
+def IsCompletelyMixedBehaviorStrategy {i : ι} (β : G.BehaviorStrategy i) : Prop :=
+  ∀ (k : G.InfoSet) (s : G.State) (hinfo : G.info s = some k)
+    (hmover : G.mover s = some i) [Fintype (G.Action s)] (a : G.Action s),
+      0 < (β.mixedActionAt G hinfo hmover).val a
+
+/-- A behavior profile is completely mixed if every player's behavior strategy
+    is completely mixed. -/
+def IsCompletelyMixedBehaviorProfile (β : G.BehaviorProfile) : Prop :=
+  ∀ i : ι, G.IsCompletelyMixedBehaviorStrategy (β i)
+
+/-- A completely mixed behavior profile gives a completely mixed behavior
+    strategy for each player. -/
+theorem IsCompletelyMixedBehaviorProfile.player {β : G.BehaviorProfile}
+    (hβ : G.IsCompletelyMixedBehaviorProfile β) (i : ι) :
+    G.IsCompletelyMixedBehaviorStrategy (β i) :=
+  hβ i
+
+/-- Complete mixing is preserved when a behavior strategy is restricted to a
+    re-rooted subgame. -/
+theorem isCompletelyMixedBehaviorStrategy_restrictToSubgame {i : ι}
+    {β : G.BehaviorStrategy i} (hβ : G.IsCompletelyMixedBehaviorStrategy β)
+    (root : G.State) :
+    (G.subgameAt root).IsCompletelyMixedBehaviorStrategy
+      (BehaviorStrategy.restrictToSubgame G β root) := by
+  intro k s hinfo hmover hfin a
+  letI : Fintype (G.Action s) := hfin
+  exact hβ k s (by simpa [subgameAt] using hinfo)
+    (by simpa [subgameAt] using hmover) a
+
+/-- Complete mixing is preserved when a behavior profile is restricted to a
+    re-rooted subgame. -/
+theorem isCompletelyMixedBehaviorProfile_restrictToSubgame {β : G.BehaviorProfile}
+    (hβ : G.IsCompletelyMixedBehaviorProfile β) (root : G.State) :
+    (G.subgameAt root).IsCompletelyMixedBehaviorProfile
+      (BehaviorProfile.restrictToSubgame G β root) := by
+  intro i
+  exact isCompletelyMixedBehaviorStrategy_restrictToSubgame
+    (G := G) (β := β i) (IsCompletelyMixedBehaviorProfile.player (G := G) hβ i) root
+
+/-- The uniform mixed action at a finite nonempty action set. -/
+def uniformBehaviorAction {s : G.State} [Fintype (G.Action s)]
+    [Nonempty (G.Action s)] : stdSimplex ℚ (G.Action s) where
+  val _ := 1 / Fintype.card (G.Action s)
+  property := ⟨fun _ => by positivity,
+               by simp [Finset.sum_const, Finset.card_univ]⟩
+
+/-- The uniform behavior action assigns positive probability to every action. -/
+theorem uniformBehaviorAction_pos {s : G.State} [Fintype (G.Action s)]
+    [Nonempty (G.Action s)] (a : G.Action s) :
+    0 < (G.uniformBehaviorAction (s := s)).val a := by
+  exact one_div_pos.mpr (Nat.cast_pos.mpr (Fintype.card_pos (α := G.Action s)))
+
+/-- Uniform behavior strategy, available when every queried information-set
+    action type is nonempty. Finiteness is supplied by the behavior-strategy
+    query itself. -/
+def uniformBehaviorStrategy (i : ι)
+    (hNonempty : ∀ (k : G.InfoSet) (s : G.State) (_hinfo : G.info s = some k)
+      (_hmover : G.mover s = some i), Nonempty (G.Action s)) :
+    G.BehaviorStrategy i :=
+  fun k s hinfo hmover hfin => by
+    letI : Fintype (G.Action s) := hfin
+    letI : Nonempty (G.Action s) := hNonempty k s hinfo hmover
+    exact G.uniformBehaviorAction (s := s)
+
+/-- Uniform behavior profile. -/
+def uniformBehaviorProfile
+    (hNonempty : ∀ (i : ι) (k : G.InfoSet) (s : G.State)
+      (_hinfo : G.info s = some k) (_hmover : G.mover s = some i),
+        Nonempty (G.Action s)) :
+    G.BehaviorProfile :=
+  fun i => G.uniformBehaviorStrategy i (hNonempty i)
+
+/-- The uniform behavior strategy is completely mixed. -/
+theorem uniformBehaviorStrategy_isCompletelyMixed (i : ι)
+    (hNonempty : ∀ (k : G.InfoSet) (s : G.State) (_hinfo : G.info s = some k)
+      (_hmover : G.mover s = some i), Nonempty (G.Action s)) :
+    G.IsCompletelyMixedBehaviorStrategy (G.uniformBehaviorStrategy i hNonempty) := by
+  intro k s hinfo hmover hfin a
+  letI : Fintype (G.Action s) := hfin
+  letI : Nonempty (G.Action s) := hNonempty k s hinfo hmover
+  change 0 < (G.uniformBehaviorAction (s := s)).val a
+  exact G.uniformBehaviorAction_pos (s := s) a
+
+/-- The uniform behavior profile is completely mixed. -/
+theorem uniformBehaviorProfile_isCompletelyMixed
+    (hNonempty : ∀ (i : ι) (k : G.InfoSet) (s : G.State)
+      (_hinfo : G.info s = some k) (_hmover : G.mover s = some i),
+        Nonempty (G.Action s)) :
+    G.IsCompletelyMixedBehaviorProfile (G.uniformBehaviorProfile hNonempty) := by
+  intro i
+  exact G.uniformBehaviorStrategy_isCompletelyMixed i (hNonempty i)
 
 end FiniteImperfectGame
 
@@ -183,5 +485,93 @@ theorem tiny_same_mover : tiny.SameMoverOnInfo := by
 theorem tiny_no_chance_on_info : tiny.NoChanceOnDecisionInfo := by
   intro s k hs
   cases s <;> cases k <;> simp [tiny] at hs ⊢
+
+theorem tiny_info_well_formed : tiny.InfoWellFormed := by
+  refine ⟨tiny_same_mover, ?_, tiny_no_chance_on_info⟩
+  intro s t k hs ht
+  cases s <;> cases t <;> cases k <;> simp [tiny] at hs ht ⊢
+  · exact ⟨Equiv.refl P1Action⟩
+  · exact ⟨Equiv.refl P1Action⟩
+  · exact ⟨Equiv.refl P1Action⟩
+  · exact ⟨Equiv.refl P1Action⟩
+
+/-- The left information-set state is reachable from the root. -/
+theorem tiny_left_reachable : tiny.IsReachable State.left := by
+  change tiny.Reachable State.root State.left
+  exact FiniteImperfectGame.Reachable.step (G := tiny) RootAction.L
+    (FiniteImperfectGame.Reachable.refl (G := tiny) State.left)
+
+/-- Every player-1 information-set query in `tiny` has a nonempty action set. -/
+theorem tinyP1_info_action_nonempty :
+    ∀ (k : tiny.InfoSet) (s : tiny.State) (_hinfo : tiny.info s = some k)
+      (_hmover : tiny.mover s = some Player.P1), Nonempty (tiny.Action s) := by
+  intro k s hinfo hmover
+  cases s <;> cases k <;> simp [tiny] at hinfo hmover ⊢
+  · exact ⟨P1Action.Stop⟩
+  · exact ⟨P1Action.Stop⟩
+
+/-- A uniform behavior strategy for player 1 at the hidden-choice information
+    set. -/
+def tinyP1Behavior : tiny.BehaviorStrategy Player.P1 :=
+  tiny.uniformBehaviorStrategy Player.P1 tinyP1_info_action_nonempty
+
+/-- The singleton-action behavior strategy at the hidden-choice information set
+    is completely mixed. -/
+theorem tinyP1Behavior_completely_mixed :
+    tiny.IsCompletelyMixedBehaviorStrategy tinyP1Behavior := by
+  exact tiny.uniformBehaviorStrategy_isCompletelyMixed
+    Player.P1 tinyP1_info_action_nonempty
+
+/-- The subgame rooted at the left hidden-choice state. -/
+def tinyLeftSubgame : FiniteImperfectGame Player ℤ :=
+  tiny.subgameAt State.left
+
+/-- The left state is the root of `tinyLeftSubgame`, hence reachable there. -/
+theorem tinyLeftSubgame_left_reachable :
+    tinyLeftSubgame.IsReachable State.left := by
+  exact tiny.subgameAt_isReachable_root State.left
+
+/-- The left subgame inherits the information-set well-formedness package. -/
+theorem tinyLeftSubgame_info_well_formed :
+    tinyLeftSubgame.InfoWellFormed := by
+  exact tiny.subgameAt_infoWellFormed tiny_info_well_formed
+
+/-- Re-rooting the tiny game at `left` does not change the hidden-choice
+    information label there. -/
+theorem tinyLeftSubgame_left_info :
+    tinyLeftSubgame.info State.left = some Info.hiddenChoice := by
+  rw [show tinyLeftSubgame.info State.left =
+      tiny.info State.left from tiny.subgameAt_info State.left State.left]
+  rfl
+
+/-- Re-rooting the tiny game at `left` does not change the player at `left`. -/
+theorem tinyLeftSubgame_left_mover :
+    tinyLeftSubgame.mover State.left = some Player.P1 := by
+  rw [show tinyLeftSubgame.mover State.left =
+      tiny.mover State.left from tiny.subgameAt_mover State.left State.left]
+  rfl
+
+/-- The terminal stop state is reachable from the left subgame root. -/
+theorem tinyLeftSubgame_stop_reachable :
+    tinyLeftSubgame.IsReachable State.stop := by
+  exact FiniteImperfectGame.IsReachable.next
+    (G := tinyLeftSubgame) tinyLeftSubgame_left_reachable P1Action.Stop
+
+/-- The terminal stop state is reachable in the original tiny game through the
+    left hidden-choice state. -/
+theorem tiny_stop_reachable_via_left_subgame :
+    tiny.IsReachable State.stop :=
+  FiniteImperfectGame.IsReachable.next
+    (G := tiny) tiny_left_reachable P1Action.Stop
+
+/-- Restrict the player-1 behavior strategy to the left subgame. -/
+def tinyP1BehaviorOnLeft : tinyLeftSubgame.BehaviorStrategy Player.P1 :=
+  tinyP1Behavior.restrictToSubgame tiny State.left
+
+/-- The restricted behavior strategy remains completely mixed in the subgame. -/
+theorem tinyP1BehaviorOnLeft_completely_mixed :
+    tinyLeftSubgame.IsCompletelyMixedBehaviorStrategy tinyP1BehaviorOnLeft := by
+  exact FiniteImperfectGame.isCompletelyMixedBehaviorStrategy_restrictToSubgame
+    (G := tiny) (β := tinyP1Behavior) tinyP1Behavior_completely_mixed State.left
 
 end Examples.ImperfectInformation

--- a/EconCSLib/GameTheory/ExtensiveGame/Strategy.lean
+++ b/EconCSLib/GameTheory/ExtensiveGame/Strategy.lean
@@ -34,7 +34,7 @@ def StrategyProfile (G : ExtensiveGame N U) :=
     Returns `none` at chance states (mover = none). -/
 def StrategyProfile.actionAt [DecidableEq N] {G : ExtensiveGame N U}
     (σ : StrategyProfile G) (s : G.State) :
-    Option (Σ i : N, G.Action s) :=
+    Option (Σ _ : N, G.Action s) :=
   match h : G.mover s with
   | some i => some ⟨i, σ i s h⟩
   | none => none

--- a/EconCSLib/GameTheory/ExtensiveGame/Zermelo.lean
+++ b/EconCSLib/GameTheory/ExtensiveGame/Zermelo.lean
@@ -8,7 +8,7 @@ import Mathlib.Algebra.Order.Ring.Rat
 import Mathlib.Tactic.Linarith
 
 /-!
-# EconCSLib.GameTheory.ExtensiveGame.Zermelo
+# ExtensiveGame.Zermelo
 
 **Zermelo-style finite game results** as two-player zero-sum consequences of
 backward induction and Kuhn's theorem.
@@ -17,7 +17,7 @@ Zermelo (1913) established determinacy for finite perfect-information
 two-player win/loss/draw games (Chess, in his original paper).
 Here we frame it as the special case of Kuhn's theorem where:
 
-* `N = Fin 2` — exactly two players,
+* `ι = Fin 2` — exactly two players,
 * payoffs are in `ℚ` (any `[LinearOrderedField U]` would do),
 * the game is **zero-sum**: `payoff leaf 0 + payoff leaf 1 = 0` at every leaf.
 
@@ -28,26 +28,27 @@ Here we frame it as the special case of Kuhn's theorem where:
 
 ## Main results
 
-* `zermelo_determinacy` — **determinacy / saddle value**: in a finite two-player
-  zero-sum perfect-information game, `optStrategy` is a saddle point with value
-  `value₀ g`. Player 0, by playing `optStrategy`, secures at least `value₀ g`
-  against every opponent play; player 1, by playing `optStrategy`, holds player 0
-  to at most `value₀ g`. This is the genuine Zermelo content (the value is
-  determined and both players have a pure optimal strategy).
-* `IsZeroSum.of_subtree` — zero-sumness is inherited by every subgame.
-* `outcome_zero_sum` — every strategy's terminal outcome is zero-sum in a
-  zero-sum tree.
+* `IsZeroSum.of_subtree` / `IsZeroSum.of_properSubgame` — zero-sumness is
+  inherited by subgames.
+* `zermelo_exists_pure_SPE` — every finite 2-player zero-sum perfect-info game
+  has a pure-strategy subgame-perfect equilibrium.
+* `zermelo_exists_pure_SPE_on` — the root-scoped SPE version.
+* `zermelo_exists_pure_NE` — the same game has a pure-strategy Nash equilibrium
+  at the root.
+* `zermelo_exists_pure_NE_on_subtrees` — one pure strategy is Nash on every
+  subtree of the root.
+* `zermelo_exists_pure_SPE_on_subtree` /
+  `zermelo_exists_pure_NE_on_subtree` — fixed-subtree versions.
+* `zermelo_exists_pure_SPE_on_properSubgames` /
+  `zermelo_exists_pure_NE_on_properSubgames` — proper-subgame versions.
 * `value_zero_sum` — backward induction preserves the zero-sum value invariant.
 * `value_one_eq_neg_value₀` — player 1's backward-induction value is the
   negative of player 0's value.
 * `value₀_Node_zero_isMax` / `value₀_Node_one_isMin` — the local max/min
   behavior of the zero-sum value at player-0 and player-1 nodes.
-* `value₀_eq_outcome_and_zeroSum` — `optStrategy` realizes the player-0 value and
-  the value vector is zero-sum (packaging lemma; the saddle statement is
-  `zermelo_determinacy`).
-* `zermelo_exists_pure_SPE` / `zermelo_exists_pure_NE` — the `Fin 2` / `ℚ`
-  instances of Kuhn's existence theorem. **Existence needs no zero-sum
-  hypothesis**; the zero-sum refinement is `zermelo_determinacy`.
+* `outcome_optStrategy_zero_sum` — the backward-induction strategy reaches a
+  zero-sum terminal outcome.
+* `value₀_eq_optStrategy_outcome` — `optStrategy` realizes the player-0 value.
 
 ## References
 
@@ -100,26 +101,117 @@ theorem IsZeroSum.of_subtree {s g : GameTree (Fin 2) ℚ}
   | inHead m h t _ ih => exact ih (IsZeroSum.head hzs)
   | inTail m h t hmem _ ih => exact ih (IsZeroSum.tail_mem hzs hmem)
 
-/-! ### Existence (instances of Kuhn's theorem)
+/-- Zero-sumness is inherited by proper subgames. -/
+theorem IsZeroSum.of_properSubgame {s g : GameTree (Fin 2) ℚ}
+    (hzs : IsZeroSum g) (hproper : ProperSubgame s g) : IsZeroSum s :=
+  hzs.of_subtree hproper.toSubtree
 
-Existence of a pure SPE / Nash equilibrium is **Kuhn's theorem**; it holds for
-any finite perfect-information game and does **not** use the zero-sum
-hypothesis. These two declarations are just the `Fin 2` / `ℚ` instances, kept as
-named entry points. The genuinely zero-sum result — that the game has a
-determined value realized by a saddle point — is `zermelo_determinacy` below. -/
+/-! ### Existence theorem -/
 
-/-- Pure root-scoped subgame-perfect existence for a finite two-player game on
-    `ℚ`: the `Fin 2` / `ℚ` instance of `Kuhn_exists_SPE_on`. Zero-sum is **not**
-    needed for existence; see `zermelo_determinacy` for the zero-sum refinement. -/
-theorem zermelo_exists_pure_SPE (g : GameTree (Fin 2) ℚ) :
+/-- **Zermelo's theorem** (existence form): every finite two-player zero-sum
+    perfect-information game admits a pure-strategy subgame-perfect equilibrium.
+
+    This is the specialization of Kuhn's theorem (`Kuhn_exists_SPE`) to the
+    2-player zero-sum setting on rationals. The zero-sum hypothesis is part of
+    the Zermelo-style statement; existence itself follows from Kuhn's theorem. -/
+theorem zermelo_exists_pure_SPE (g : GameTree (Fin 2) ℚ) (_hzs : IsZeroSum g) :
+    ∃ σ : Strategy (Fin 2) ℚ, IsSubgamePerfect σ :=
+  Kuhn_exists_SPE
+
+/-- Every finite two-player zero-sum perfect-information game admits a
+    root-scoped pure-strategy subgame-perfect equilibrium. -/
+theorem zermelo_exists_pure_SPE_on (g : GameTree (Fin 2) ℚ) (_hzs : IsZeroSum g) :
     ∃ σ : Strategy (Fin 2) ℚ, IsSubgamePerfectOn σ g :=
   Kuhn_exists_SPE_on g
 
-/-- Pure root Nash existence for a finite two-player game on `ℚ`: the `Fin 2` /
-    `ℚ` instance of `Kuhn_exists_NE`. Zero-sum is **not** needed. -/
-theorem zermelo_exists_pure_NE (g : GameTree (Fin 2) ℚ) :
-    ∃ σ : Strategy (Fin 2) ℚ, IsNashEquilibrium σ g :=
-  Kuhn_exists_NE g
+/-- Every finite two-player zero-sum perfect-information game admits a
+    pure-strategy Nash equilibrium at the root. -/
+theorem zermelo_exists_pure_NE (g : GameTree (Fin 2) ℚ) (hzs : IsZeroSum g) :
+    ∃ σ : Strategy (Fin 2) ℚ, IsNashEquilibrium σ g := by
+  obtain ⟨σ, hspe⟩ := zermelo_exists_pure_SPE g hzs
+  exact ⟨σ, hspe.toNE g⟩
+
+/-- Every finite two-player zero-sum perfect-information game admits one pure
+    strategy that is subgame-perfect on every subtree of the root. -/
+theorem zermelo_exists_pure_SPE_on_subtrees
+    (g : GameTree (Fin 2) ℚ) (_hzs : IsZeroSum g) :
+    ∃ σ : Strategy (Fin 2) ℚ,
+      ∀ s : GameTree (Fin 2) ℚ, Subtree s g → IsSubgamePerfectOn σ s :=
+  Kuhn_exists_SPE_on_subtrees g
+
+/-- Every finite two-player zero-sum perfect-information game admits one pure
+    strategy that is Nash on every subtree of the root. -/
+theorem zermelo_exists_pure_NE_on_subtrees
+    (g : GameTree (Fin 2) ℚ) (_hzs : IsZeroSum g) :
+    ∃ σ : Strategy (Fin 2) ℚ,
+      ∀ s : GameTree (Fin 2) ℚ, Subtree s g → IsNashAt σ s :=
+  Kuhn_exists_NE_on_subtrees g
+
+/-- Every zero-sum subtree admits a root-scoped pure-strategy
+    subgame-perfect equilibrium. -/
+theorem zermelo_exists_pure_SPE_on_subtree
+    {s g : GameTree (Fin 2) ℚ} (hzs : IsZeroSum g) (hsub : Subtree s g) :
+    ∃ σ : Strategy (Fin 2) ℚ, IsSubgamePerfectOn σ s :=
+  zermelo_exists_pure_SPE_on s (hzs.of_subtree hsub)
+
+/-- Every zero-sum subtree admits a pure-strategy Nash equilibrium at its
+    root. -/
+theorem zermelo_exists_pure_NE_on_subtree
+    {s g : GameTree (Fin 2) ℚ} (hzs : IsZeroSum g) (hsub : Subtree s g) :
+    ∃ σ : Strategy (Fin 2) ℚ, IsNashAt σ s := by
+  obtain ⟨σ, hspe⟩ := zermelo_exists_pure_SPE_on_subtree hzs hsub
+  exact ⟨σ, hspe.toNashAt⟩
+
+/-- Every finite two-player zero-sum perfect-information game admits one pure
+    strategy that is subgame-perfect on every proper subgame of the root. -/
+theorem zermelo_exists_pure_SPE_on_properSubgames
+    (g : GameTree (Fin 2) ℚ) (_hzs : IsZeroSum g) :
+    ∃ σ : Strategy (Fin 2) ℚ,
+      ∀ s : GameTree (Fin 2) ℚ, ProperSubgame s g → IsSubgamePerfectOn σ s :=
+  Kuhn_exists_SPE_on_properSubgames g
+
+/-- Every finite two-player zero-sum perfect-information game admits one pure
+    strategy that is Nash on every proper subgame of the root. -/
+theorem zermelo_exists_pure_NE_on_properSubgames
+    (g : GameTree (Fin 2) ℚ) (_hzs : IsZeroSum g) :
+    ∃ σ : Strategy (Fin 2) ℚ,
+      ∀ s : GameTree (Fin 2) ℚ, ProperSubgame s g → IsNashAt σ s :=
+  Kuhn_exists_NE_on_properSubgames g
+
+/-- Every proper zero-sum subgame admits a root-scoped pure-strategy
+    subgame-perfect equilibrium. -/
+theorem zermelo_exists_pure_SPE_on_properSubgame
+    {s g : GameTree (Fin 2) ℚ} (hzs : IsZeroSum g)
+    (hproper : ProperSubgame s g) :
+    ∃ σ : Strategy (Fin 2) ℚ, IsSubgamePerfectOn σ s :=
+  zermelo_exists_pure_SPE_on_subtree hzs hproper.toSubtree
+
+/-- Every proper zero-sum subgame admits a pure-strategy Nash equilibrium at
+    its root. -/
+theorem zermelo_exists_pure_NE_on_properSubgame
+    {s g : GameTree (Fin 2) ℚ} (hzs : IsZeroSum g)
+    (hproper : ProperSubgame s g) :
+    ∃ σ : Strategy (Fin 2) ℚ, IsNashAt σ s :=
+  zermelo_exists_pure_NE_on_subtree hzs hproper.toSubtree
+
+/-- Every finite two-player zero-sum perfect-information game admits one pure
+    strategy that is Nash at the root and Nash on every proper subgame. -/
+theorem zermelo_exists_pure_NE_and_NE_on_properSubgames
+    (g : GameTree (Fin 2) ℚ) (_hzs : IsZeroSum g) :
+    ∃ σ : Strategy (Fin 2) ℚ,
+      IsNashAt σ g ∧
+        ∀ s : GameTree (Fin 2) ℚ, ProperSubgame s g → IsNashAt σ s :=
+  Kuhn_exists_NE_and_NE_on_properSubgames g
+
+/-- Every finite two-player zero-sum perfect-information game admits one pure
+    strategy that is Nash at the root and subgame-perfect on every proper
+    subgame. -/
+theorem zermelo_exists_pure_NE_and_SPE_on_properSubgames
+    (g : GameTree (Fin 2) ℚ) (_hzs : IsZeroSum g) :
+    ∃ σ : Strategy (Fin 2) ℚ,
+      IsNashAt σ g ∧
+        ∀ s : GameTree (Fin 2) ℚ, ProperSubgame s g → IsSubgamePerfectOn σ s :=
+  Kuhn_exists_NE_and_SPE_on_properSubgames g
 
 /-! ### Backward-induction value in zero-sum games -/
 
@@ -127,7 +219,7 @@ theorem zermelo_exists_pure_NE (g : GameTree (Fin 2) ℚ) :
 
     Under zero-sum, this fully determines both players' values
     (player 1's value = `-value₀`). -/
-def value₀ (g : GameTree (Fin 2) ℚ) : ℚ :=
+noncomputable def value₀ (g : GameTree (Fin 2) ℚ) : ℚ :=
   (value g) 0
 
 /-- At a zero-sum leaf, `value₀` equals player 0's payoff and
@@ -222,29 +314,13 @@ theorem value₀_Node_one_isMin (h : GameTree (Fin 2) ℚ)
 
 /-! ### Backward-induction outcome in zero-sum games -/
 
-/-- In a zero-sum tree, the terminal outcome of **any** strategy is zero-sum:
-    following any strategy ends at some leaf, and every leaf of a zero-sum tree
-    is zero-sum. This is the strategy-level analogue of `value_zero_sum`. -/
-theorem outcome_zero_sum (σ : Strategy (Fin 2) ℚ) (g : GameTree (Fin 2) ℚ)
-    (hzs : IsZeroSum g) :
-    outcome σ g 0 + outcome σ g 1 = 0 := by
-  revert hzs
-  induction g using GameTree.strong_induction with
-  | base p =>
-      intro hzs
-      simpa [outcome_Leaf, IsZeroSum] using hzs
-  | step m h t ih =>
-      intro hzs
-      rw [outcome_Node]
-      have hmem : (σ m h t).val ∈ h :: t := (σ m h t).property
-      exact ih _ hmem (IsZeroSum.child_mem hzs hmem)
-
 /-- The terminal outcome reached by the backward-induction strategy is
     zero-sum whenever the game tree is zero-sum. -/
 theorem outcome_optStrategy_zero_sum (g : GameTree (Fin 2) ℚ) (hzs : IsZeroSum g) :
     outcome (optStrategy : Strategy (Fin 2) ℚ) g 0 +
-      outcome (optStrategy : Strategy (Fin 2) ℚ) g 1 = 0 :=
-  outcome_zero_sum optStrategy g hzs
+      outcome (optStrategy : Strategy (Fin 2) ℚ) g 1 = 0 := by
+  rw [outcome_optStrategy_eq_value]
+  exact value_zero_sum g hzs
 
 /-- In a zero-sum game, the backward-induction outcome for player 1 is the
     negative of player 0's backward-induction value. -/
@@ -262,66 +338,12 @@ theorem value₀_eq_optStrategy_outcome (g : GameTree (Fin 2) ℚ) :
   unfold value₀
   rw [outcome_optStrategy_eq_value]
 
-/-- Packaging lemma: the backward-induction strategy realizes player 0's value,
-    and the value vector is zero-sum. This is *not* the minimax statement — it
-    has no quantification over opponent strategies. The genuine saddle / security
-    statement is `zermelo_determinacy`. -/
-theorem value₀_eq_outcome_and_zeroSum (g : GameTree (Fin 2) ℚ) (hzs : IsZeroSum g) :
+/-- A real value theorem for finite zero-sum perfect-information trees:
+    the backward-induction strategy realizes player 0's value, and the value
+    vector is zero-sum. -/
+theorem value₀_minimax_prop (g : GameTree (Fin 2) ℚ) (hzs : IsZeroSum g) :
     value₀ g = outcome (optStrategy : Strategy (Fin 2) ℚ) g 0 ∧
       (value g) 1 = -value₀ g :=
   ⟨value₀_eq_optStrategy_outcome g, value_one_eq_neg_value₀ g hzs⟩
-
-/-! ### Determinacy (the saddle value)
-
-The genuine Zermelo content. Combining subgame perfection of `optStrategy`
-(`optStrategy_isSubgamePerfect`) with the zero-sum invariant gives a saddle
-point: `value₀ g` is simultaneously what player 0 can secure and what player 1
-can hold player 0 to. -/
-
-/-- **Player 0's security.** If player 0 plays `optStrategy` (so the deviating
-    profile `σ'` is a `1`-variant, leaving player 0's choices fixed), then player
-    0's payoff is at least `value₀ g` against *every* play of player 1.
-
-    Proof: subgame perfection at player 1 caps `outcome σ' g 1 ≤ value g 1 =
-    -value₀ g`; the zero-sum identity `outcome σ' g 0 = -outcome σ' g 1` then
-    forces `outcome σ' g 0 ≥ value₀ g`. -/
-theorem value₀_le_outcome_of_iVariant_one (g : GameTree (Fin 2) ℚ)
-    (hzs : IsZeroSum g) {σ' : Strategy (Fin 2) ℚ}
-    (hiv : IVariant (1 : Fin 2) optStrategy σ') :
-    value₀ g ≤ outcome σ' g 0 := by
-  have h1 := optStrategy_isSubgamePerfect g (1 : Fin 2) σ' hiv
-  rw [outcome_optStrategy_eq_value, value_one_eq_neg_value₀ g hzs] at h1
-  have hsum := outcome_zero_sum σ' g hzs
-  linarith
-
-/-- **Player 1's security.** If player 1 plays `optStrategy` (so `σ'` is a
-    `0`-variant, leaving player 1's choices fixed), then player 0's payoff is at
-    most `value₀ g` against *every* play of player 0. Immediate from subgame
-    perfection at player 0; no zero-sum hypothesis is needed for this direction. -/
-theorem outcome_le_value₀_of_iVariant_zero (g : GameTree (Fin 2) ℚ)
-    {σ' : Strategy (Fin 2) ℚ} (hiv : IVariant (0 : Fin 2) optStrategy σ') :
-    outcome σ' g 0 ≤ value₀ g := by
-  have h0 := optStrategy_isSubgamePerfect g (0 : Fin 2) σ' hiv
-  rw [outcome_optStrategy_eq_value] at h0
-  simpa [value₀] using h0
-
-/-- **Zermelo's theorem (determinacy / saddle value).** In a finite two-player
-    zero-sum perfect-information game, `optStrategy` is a saddle point with value
-    `value₀ g`:
-
-    * playing `optStrategy`, player 0 *secures* at least `value₀ g` against every
-      opponent play (`1`-variant);
-    * playing `optStrategy`, player 1 *holds* player 0 to at most `value₀ g`
-      against every opponent play (`0`-variant).
-
-    Hence the game is determined and `value₀ g` is its value, attained by the
-    pure backward-induction strategy on both sides. -/
-theorem zermelo_determinacy (g : GameTree (Fin 2) ℚ) (hzs : IsZeroSum g) :
-    (∀ σ' : Strategy (Fin 2) ℚ, IVariant (1 : Fin 2) optStrategy σ' →
-        value₀ g ≤ outcome σ' g 0) ∧
-    (∀ σ' : Strategy (Fin 2) ℚ, IVariant (0 : Fin 2) optStrategy σ' →
-        outcome σ' g 0 ≤ value₀ g) :=
-  ⟨fun _ hiv => value₀_le_outcome_of_iVariant_one g hzs hiv,
-   fun _ hiv => outcome_le_value₀_of_iVariant_zero g hiv⟩
 
 end GameTree


### PR DESCRIPTION
## Summary

Describe the mathematical or repository change.

## Scope

List the Lean modules, blueprint nodes, or documentation files affected.

## Verification

- [ ] `lake build`
- [ ] `lake build EconCSLib.Examples`
- [ ] `python3 scripts/check_lean_placeholders.py EconCSLib` passed
- [ ] `git diff --check`
- [ ] Blueprint checks run when `docs/knowledge/` changed

## Notes

Record API decisions, remaining blueprint gaps, or follow-up issues.
