### PR TITLE
Add exact finite absorbing Markov-chain foundation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,11 @@ jobs:
           lake env lean tests/FiniteLawSmoke.lean
           lake env lean tests/FiniteLawAudit.lean
 
+      - name: Validate exact finite absorbing chains
+        run: |
+          lake env lean tests/FiniteMarkovChainSmoke.lean
+          lake env lean tests/FiniteMarkovChainAudit.lean
+
       - name: Check Lean sources for placeholders
         run: python3 scripts/check_lean_placeholders.py EconCSLib
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,11 @@ jobs:
       - name: Build examples
         run: lake build EconCSLib.Examples
 
+      - name: Validate executable finite probability
+        run: |
+          lake env lean tests/FiniteLawSmoke.lean
+          lake env lean tests/FiniteLawAudit.lean
+
       - name: Check Lean sources for placeholders
         run: python3 scripts/check_lean_placeholders.py EconCSLib
 

--- a/EconCSLib.lean
+++ b/EconCSLib.lean
@@ -27,6 +27,9 @@ import EconCSLib.Algorithm.Online
 -- Math: infrastructure with no game vocabulary
 import EconCSLib.Math.Simplex
 
+-- Math/Probability: exact executable finite laws
+import EconCSLib.Math.Probability.FiniteLaw
+
 -- Math/LinearAlgebra
 import EconCSLib.Math.LinearAlgebra.FourierMotzkin
 import EconCSLib.Math.LinearAlgebra.Farkas

--- a/EconCSLib.lean
+++ b/EconCSLib.lean
@@ -29,6 +29,7 @@ import EconCSLib.Math.Simplex
 
 -- Math/Probability: exact executable finite laws
 import EconCSLib.Math.Probability.FiniteLaw
+import EconCSLib.Math.Probability.FiniteMarkovChain
 
 -- Math/LinearAlgebra
 import EconCSLib.Math.LinearAlgebra.FourierMotzkin

--- a/EconCSLib/Examples.lean
+++ b/EconCSLib/Examples.lean
@@ -12,6 +12,7 @@ import EconCSLib.Examples.ExtensiveGame.LegacyApiMigration
 import EconCSLib.Examples.ExtensiveGame.ObservedInfoRealization
 import EconCSLib.Examples.ExtensiveGame.StructuralCoreImportBoundary
 import EconCSLib.Examples.ExtensiveGame.TerminalMoverIgnored
+import EconCSLib.Examples.FiniteMarkovChain
 import EconCSLib.Examples.MatchingPennies
 import EconCSLib.Examples.PrisonersDilemma
 import EconCSLib.Examples.RockPaperScissors

--- a/EconCSLib/Examples/FiniteMarkovChain.lean
+++ b/EconCSLib/Examples/FiniteMarkovChain.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2026 EconCSLib contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+
+import EconCSLib.Math.Probability.FiniteMarkovChain.Semantics
+
+/-!
+# Exact finite absorbing-chain examples
+
+These models use the library's `FiniteMarkovChain.Chain` directly. Read the
+geometric model first, then the two-stage and cyclic models, and finally the
+full-domain rejection example. Runtime regressions live in
+`tests/FiniteMarkovChainSmoke.lean`; the propositions below are ordinary Lean
+proofs instantiating the library's analytic correctness theorems.
+-/
+
+namespace Examples.FiniteMarkovChain
+
+open _root_.FiniteMarkovChain MeasureTheory
+
+section Models
+
+/-- A fair repeat-or-stop experiment with terminal reward six. -/
+def geometric : Chain 1 1 where
+  transient _ _ := 1 / 2
+  terminal _ _ := 1 / 2
+  normalized := by intro i; norm_num
+  reward _ := 6
+
+/-- One mandatory transition followed by a geometric wait and two terminal outcomes. -/
+def twoStage : Chain 2 2 where
+  transient i j := if j = 1 then if i = 0 then 1 else 1 / 2 else 0
+  terminal i _ := if i = 0 then 0 else 1 / 4
+  normalized := by intro i; fin_cases i <;> norm_num [Fin.sum_univ_two]
+  reward a := if a = 0 then -2 else 6
+
+/-- A two-state cycle with a fair chance to exit on every second transition. -/
+def cyclic : Chain 2 1 where
+  transient i j := if i = 0 then if j = 1 then 1 else 0
+    else if j = 0 then 1 / 2 else 0
+  terminal i _ := if i = 0 then 0 else 1 / 2
+  normalized := by intro i; fin_cases i <;> norm_num [Fin.sum_univ_two]
+  reward _ := 5
+
+/-- State zero terminates immediately; state one is a closed class. -/
+def partiallyClosed : Chain 2 1 where
+  transient i j := if i = 1 ∧ j = 1 then 1 else 0
+  terminal i _ := if i = 0 then 1 else 0
+  normalized := by intro i; fin_cases i <;> norm_num [Fin.sum_univ_two]
+  reward _ := 6
+
+/-- No transient starts: absorption is vacuous and terminal values remain defined. -/
+def noTransient : Chain 0 1 where
+  transient i := Fin.elim0 i
+  terminal i := Fin.elim0 i
+  normalized i := Fin.elim0 i
+  reward _ := -3
+
+end Models
+
+section GeometricSemantics
+
+private lemma geometric_reaches (i : Fin 1) :
+    ∃ horizon, geometric.survival horizon i < 1 := by
+  refine ⟨1, ?_⟩
+  norm_num [Chain.survival, Chain.Q, geometric]
+
+/-- The automatic checker certifies the actual geometric model. -/
+lemma geometric_autoCheck : geometric.autoCheck = true :=
+  geometric.autoCheck_iff_reaches.mpr geometric_reaches
+
+/-- The joint first-hit law is normalized, although finite runs retain unfinished mass. -/
+theorem geometric_firstHit_probability :
+    IsProbabilityMeasure (Measure.sum fun p : ℕ × Fin 1 =>
+      ENNReal.ofReal (geometric.hit p.1 0 p.2 : ℝ) • Measure.dirac p) :=
+  geometric.firstHit_probability geometric_autoCheck 0
+
+/-- Exact automatic solving succeeds without a caller-supplied candidate or inverse. -/
+theorem geometric_solver_succeeds : ∃ result, geometric.autoSolve = .ok result :=
+  geometric.autoSolve_success_iff.mpr
+    (geometric.autoCheck_iff_absorbsAll.mp geometric_autoCheck)
+
+/-- The concrete geometric model has expected reward six and expected duration two. -/
+theorem geometric_integrals :
+    let μ := Measure.sum fun p : ℕ × Fin 1 =>
+      ENNReal.ofReal (geometric.hit p.1 0 p.2 : ℝ) • Measure.dirac p
+    (∫ p : ℕ × Fin 1, (geometric.reward p.2 : ℝ) ∂μ) = 6 ∧
+      (∫ p : ℕ × Fin 1, ((p.1 + 1 : ℕ) : ℝ) ∂μ) = 2 := by
+  obtain ⟨v, t, _, hv, ht, _, _, hs⟩ := geometric.autoSolve_correct geometric_autoCheck
+  have hv0 := congrFun hv 0
+  have ht0 := congrFun ht 0
+  norm_num [Matrix.mulVec, dotProduct, Chain.Q, Chain.R, geometric] at hv0 ht0
+  have hv6 : v 0 = 6 := by linarith
+  have ht2 : t 0 = 2 := by linarith
+  obtain ⟨_, _, _, he, hd⟩ := hs 0
+  simpa only [hv6, ht2, Rat.cast_ofNat] using And.intro he hd
+
+end GeometricSemantics
+
+section Consumer
+
+variable {n m : ℕ} (C : Chain n m)
+variable (h : C.autoCheck = true)
+
+include h
+
+/-- A consumer can use a computed value-duration pair as the actual pair of integrals. -/
+theorem computed_integrals (i : Fin n) (value duration : ℚ)
+    (result : C.autoSolve.map (fun vt => (vt.1 (.inl i), vt.2 (.inl i))) =
+      .ok (value, duration)) :
+    let μ := Measure.sum fun p : ℕ × Fin m =>
+      ENNReal.ofReal (C.hit p.1 i p.2 : ℝ) • Measure.dirac p
+    (∫ p : ℕ × Fin m, (C.reward p.2 : ℝ) ∂μ) = (value : ℝ) ∧
+      (∫ p : ℕ × Fin m, ((p.1 + 1 : ℕ) : ℝ) ∂μ) = (duration : ℝ) :=
+  C.autoSolve_integrals h i value duration result
+
+end Consumer
+
+end Examples.FiniteMarkovChain

--- a/EconCSLib/Math/Probability/FiniteLaw.lean
+++ b/EconCSLib/Math/Probability/FiniteLaw.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2026 EconCSLib contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+
+import EconCSLib.Math.Probability.FiniteLaw.Conditioning
+import EconCSLib.Math.Probability.FiniteLaw.Coupling
+import EconCSLib.Math.Probability.FiniteLaw.DeferredSampling
+import EconCSLib.Math.Probability.FiniteLaw.Product
+
+/-!
+# Executable finite probability
+
+Aggregate import for executable finite probability laws with exact
+nonnegative-rational weights.
+
+Start with `FiniteLaw.pure`, `FiniteLaw.map`, `FiniteLaw.bind`, and
+`FiniteLaw.expectRat` in `FiniteLaw.Core`. `Product` constructs independent
+finite families, `Conditioning` computes partial posteriors, `Coupling`
+transports related joint laws, and `DeferredSampling` proves equivalence of
+pre-sampled and on-demand fresh queries.
+
+The outcome type need not be finite or decidably equal. Equality decisions
+are explicit inputs to point-mass and fiber queries; products over a general
+finite index type require a supplied enumeration and linear order. Zero-mass
+conditioning returns `none`.
+
+`FiniteLaw.Equivalent` compares exact rational expectations, allowing atom
+lists with different orders or repeated outcomes. This executable interface
+does not construct arbitrary real-weighted distributions or infinite path
+measures.
+-/

--- a/EconCSLib/Math/Probability/FiniteLaw/Conditioning.lean
+++ b/EconCSLib/Math/Probability/FiniteLaw/Conditioning.lean
@@ -1,0 +1,375 @@
+/-
+Copyright (c) 2026 EconCSLib contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+
+import EconCSLib.Math.Probability.FiniteLaw.Product
+import Mathlib.Data.Fintype.BigOperators
+
+/-!
+# Conditioning finite executable laws
+
+Conditioning is deliberately partial.  A positive-mass Boolean event produces
+the exact rationally normalized restriction; a zero-mass event produces
+`none`.  In particular, this layer never invents an off-path posterior through
+classical choice.
+
+## Main definitions
+
+* `FiniteLaw.condition?` and `FiniteLaw.conditionOnFiber`;
+* `FiniteLaw.FiberPossible` for the positive-mass precondition.
+
+## Main statements
+
+* `FiniteLaw.mass_conditionOnFiber` is the exact normalized mass formula;
+* `FiniteLaw.Equivalent.conditionOnFiber` preserves semantic equivalence;
+* `FiniteLaw.fintypePi_conditionOnFiber_apply` conditions one independent coordinate.
+-/
+
+namespace FiniteLaw
+
+universe uα uβ
+
+/-! ## Restriction to a Boolean event -/
+
+section Events
+
+variable {α : Type*}
+
+/-- Keep event atoms at their old weight and zero every other occurrence. -/
+private def restrictAtoms (law : FiniteLaw α) (event : α → Bool) :
+    List (α × ℚ≥0) :=
+  law.atoms.map fun atom =>
+    (atom.1, if event atom.1 then atom.2 else 0)
+
+private lemma totalWeight_restrictAtoms
+    (law : FiniteLaw α) (event : α → Bool) :
+    totalWeight (restrictAtoms law event) = law.eventMass event := by
+  simp [restrictAtoms, totalWeight, eventMass, List.map_map,
+    Function.comp_def]
+
+private lemma restrictedMass [DecidableEq α]
+    (law : FiniteLaw α) (event : α → Bool) (outcome : α) :
+    ((restrictAtoms law event).map fun atom =>
+      if atom.1 = outcome then atom.2 else 0).sum =
+      if event outcome then law.mass outcome else 0 := by
+  unfold restrictAtoms mass eventMass
+  simp only [List.map_map, Function.comp_def]
+  by_cases hevent : event outcome
+  · rw [if_pos hevent]
+    apply congrArg List.sum
+    apply List.map_congr_left
+    intro atom _
+    by_cases heq : atom.1 = outcome
+    · subst outcome
+      simp [hevent]
+    · simp [heq]
+  · rw [if_neg hevent]
+    apply List.sum_eq_zero
+    intro term hterm
+    rw [List.mem_map] at hterm
+    obtain ⟨atom, _, rfl⟩ := hterm
+    by_cases heq : atom.1 = outcome
+    · subst outcome
+      simp [hevent]
+    · simp [heq]
+
+/-- Conditional law on an executable event.
+
+Returns `none` exactly when the event has zero mass. -/
+def condition? (law : FiniteLaw α) (event : α → Bool) :
+    Option (FiniteLaw α) :=
+  normalize? (restrictAtoms law event)
+
+@[simp]
+lemma condition?_eq_none_iff
+    (law : FiniteLaw α) (event : α → Bool) :
+    law.condition? event = none ↔ law.eventMass event = 0 := by
+  rw [condition?, normalize?_eq_none_iff,
+    totalWeight_restrictAtoms]
+
+end Events
+
+/-! ## Conditioning on an observed value -/
+
+section Fibers
+
+/-- The observed fiber has positive exact mass. -/
+def FiberPossible [DecidableEq β]
+    (law : FiniteLaw α) (observe : α → β) (value : β) : Prop :=
+  law.eventMass (fun sample => decide (observe sample = value)) ≠ 0
+
+/-- Posterior law after observing one fiber.
+
+An impossible fiber returns `none`; no off-path law is manufactured. -/
+def conditionOnFiber [DecidableEq β]
+    (law : FiniteLaw α) (observe : α → β) (value : β) :
+    Option (FiniteLaw α) :=
+  law.condition?
+    (fun sample => decide (observe sample = value))
+
+/-- A fiber posterior is absent exactly when the observed fiber has zero
+mass. -/
+@[simp]
+private lemma conditionOnFiber_eq_none_iff [DecidableEq β]
+    (law : FiniteLaw α) (observe : α → β) (value : β) :
+    law.conditionOnFiber observe value = none ↔
+      law.eventMass
+        (fun sample => decide (observe sample = value)) = 0 := by
+  exact condition?_eq_none_iff law _
+
+/-- A zero-mass fiber has no posterior. -/
+lemma conditionOnFiber_of_impossible [DecidableEq β]
+    (law : FiniteLaw α) (observe : α → β) (value : β)
+    (himpossible : ¬ law.FiberPossible observe value) :
+    law.conditionOnFiber observe value = none := by
+  unfold FiberPossible at himpossible
+  have hzero :
+      law.eventMass
+        (fun sample => decide (observe sample = value)) = 0 :=
+    not_ne_iff.mp himpossible
+  exact (conditionOnFiber_eq_none_iff law observe value).mpr hzero
+
+/-- Point mass of a successfully computed fiber posterior. -/
+theorem mass_conditionOnFiber [DecidableEq α] [DecidableEq β]
+    (law : FiniteLaw α) (observe : α → β) (value : β)
+    (conditioned : FiniteLaw α)
+    (hconditioned :
+      law.conditionOnFiber observe value = some conditioned)
+    (outcome : α) :
+    conditioned.mass outcome =
+      if observe outcome = value then
+        law.mass outcome /
+          law.eventMass
+            (fun sample => decide (observe sample = value))
+      else 0 := by
+  have hnonzero :
+      law.eventMass
+        (fun sample => decide (observe sample = value)) ≠ 0 := by
+    intro hzero
+    have hnone :=
+      (conditionOnFiber_eq_none_iff law observe value).mpr hzero
+    rw [hconditioned] at hnone
+    exact Option.some_ne_none _ hnone
+  have htotal :
+      totalWeight
+          (restrictAtoms law
+            (fun sample => decide (observe sample = value))) ≠ 0 := by
+    rw [totalWeight_restrictAtoms]
+    exact hnonzero
+  have hcondition :
+      conditioned =
+        normalize
+          (restrictAtoms law
+            (fun sample => decide (observe sample = value)))
+          htotal := by
+    unfold conditionOnFiber condition? normalize? at hconditioned
+    simp [htotal] at hconditioned
+    exact hconditioned.symm
+  rw [hcondition, mass_normalize,
+    totalWeight_restrictAtoms, restrictedMass]
+  by_cases heq : observe outcome = value
+  · simp [heq]
+  · simp [heq]
+
+/-- Fiber conditioning respects semantic equivalence and propagates absence
+on zero-mass fibers. -/
+theorem Equivalent.conditionOnFiber
+    [DecidableEq α] [DecidableEq β]
+    {left right : FiniteLaw α}
+    (h : left.Equivalent right)
+    (observe : α → β) (value : β) :
+    Option.Rel Equivalent
+      (left.conditionOnFiber observe value)
+      (right.conditionOnFiber observe value) := by
+  have hevent :
+      left.eventMass
+          (fun sample => decide (observe sample = value)) =
+        right.eventMass
+          (fun sample => decide (observe sample = value)) :=
+    h.eventMass
+    (fun sample => decide (observe sample = value))
+  by_cases hzero :
+      left.eventMass
+        (fun sample => decide (observe sample = value)) = 0
+  · have hleft : left.conditionOnFiber observe value = none :=
+      (conditionOnFiber_eq_none_iff left observe value).2 hzero
+    have hright : right.conditionOnFiber observe value = none :=
+      (conditionOnFiber_eq_none_iff right observe value).2
+        (hevent ▸ hzero)
+    rw [hleft, hright]
+    exact Option.Rel.none
+  · have hleft : left.conditionOnFiber observe value ≠ none := by
+      simpa [conditionOnFiber_eq_none_iff] using hzero
+    have hright : right.conditionOnFiber observe value ≠ none := by
+      intro hnone
+      exact hzero (hevent.trans
+        ((conditionOnFiber_eq_none_iff right observe value).1 hnone))
+    obtain ⟨leftConditioned, hleftConditioned⟩ :=
+      Option.ne_none_iff_exists'.mp hleft
+    obtain ⟨rightConditioned, hrightConditioned⟩ :=
+      Option.ne_none_iff_exists'.mp hright
+    rw [hleftConditioned, hrightConditioned]
+    apply Option.Rel.some
+    apply Equivalent.of_mass_eq
+    intro outcome
+    rw [mass_conditionOnFiber left observe value leftConditioned
+      hleftConditioned outcome,
+      mass_conditionOnFiber right observe value rightConditioned
+        hrightConditioned outcome, ← hevent]
+    have hmass : left.mass outcome = right.mass outcome := by
+      simpa [mass] using
+        h.eventMass (fun sample => decide (sample = outcome))
+    rw [hmass]
+
+/-- Fiber conditioning is independent of the particular equality decision
+procedure supplied for the observed value type. -/
+lemma conditionOnFiber_decidableEq_irrel
+    (first second : DecidableEq β)
+    (law : FiniteLaw α) (observe : α → β) (value : β) :
+    (@conditionOnFiber (α := α) (β := β)
+      first law observe value) =
+      (@conditionOnFiber (α := α) (β := β)
+        second law observe value) := by
+  have hinstance : first = second := Subsingleton.elim _ _
+  subst second
+  rfl
+
+end Fibers
+
+/-! ## Conditioning independent tables -/
+
+section IndependentTables
+
+/-- Conditioning one coordinate of an independent finite table preserves
+independence and updates exactly that coordinate, up to sparse-presentation
+equivalence. -/
+theorem fintypePi_conditionOnFiber_apply
+    {I : Type*} [Fintype I] [LinearOrder I]
+    {X : I → Type uα}
+    [∀ i, DecidableEq (X i)]
+    [DecidableEq ((i : I) → X i)]
+    (laws : (i : I) → FiniteLaw (X i))
+    (selected : I) (value : X selected) :
+    Option.Rel Equivalent
+      ((fintypePi laws).conditionOnFiber
+        (fun tuple => tuple selected) value)
+      ((laws selected).conditionOnFiber id value |>.map
+        (fun selectedLaw =>
+          fintypePi
+            (Function.update laws selected selectedLaw))) := by
+  classical
+  let selectedEvent : X selected → Bool :=
+    fun outcome => decide (outcome = value)
+  have heventMass :
+      (fintypePi laws).eventMass
+          (fun tuple => decide (tuple selected = value)) =
+        (laws selected).eventMass selectedEvent := by
+    have hmarginal :=
+      (fintypePi_map_apply laws selected).eventMass selectedEvent
+    rw [eventMass_map] at hmarginal
+    simpa [selectedEvent, Function.comp_def] using hmarginal
+  cases hselected : (laws selected).conditionOnFiber id value with
+  | none =>
+      have hselectedZero :
+          (laws selected).eventMass selectedEvent = 0 := by
+        exact (conditionOnFiber_eq_none_iff
+          (laws selected) id value).1 hselected
+      have hproductZero :
+          (fintypePi laws).eventMass
+            (fun tuple => decide (tuple selected = value)) = 0 := by
+        rw [heventMass, hselectedZero]
+      have hproduct :
+          (fintypePi laws).conditionOnFiber
+              (fun tuple => tuple selected) value = none :=
+        (conditionOnFiber_eq_none_iff
+          (fintypePi laws) (fun tuple => tuple selected) value).2
+          hproductZero
+      rw [hproduct]
+      simp only [Option.map]
+      exact Option.Rel.none
+  | some selectedLaw =>
+      have hselectedNonzero :
+          (laws selected).eventMass selectedEvent ≠ 0 := by
+        intro hzero
+        have hnone := (conditionOnFiber_eq_none_iff
+          (laws selected) id value).2 hzero
+        rw [hselected] at hnone
+        exact Option.some_ne_none _ hnone
+      have hproductNonzero :
+          (fintypePi laws).eventMass
+              (fun tuple => decide (tuple selected = value)) ≠ 0 := by
+        rw [heventMass]
+        exact hselectedNonzero
+      have hproductSome :
+          (fintypePi laws).conditionOnFiber
+              (fun tuple => tuple selected) value ≠ none := by
+        intro hnone
+        exact hproductNonzero
+          ((conditionOnFiber_eq_none_iff
+            (fintypePi laws) (fun tuple => tuple selected) value).1
+            hnone)
+      obtain ⟨productLaw, hproduct⟩ :=
+        Option.ne_none_iff_exists'.mp hproductSome
+      rw [hproduct]
+      simp only [Option.map]
+      apply Option.Rel.some
+      apply Equivalent.of_mass_eq
+      intro tuple
+      rw [mass_conditionOnFiber
+          (fintypePi laws) (fun tuple => tuple selected) value
+          productLaw hproduct tuple,
+        fintypePi_mass, heventMass,
+        Fintype.prod_eq_mul_prod_subtype_ne _ selected]
+      have hrest :
+          (∏ i : {i : I // i ≠ selected},
+            (Function.update laws selected
+              selectedLaw i.1).mass
+                (tuple i.1)) =
+            ∏ i : {i : I // i ≠ selected},
+              (laws i.1).mass (tuple i.1) := by
+        apply Finset.prod_congr rfl
+        intro i _
+        unfold Function.update
+        split
+        · rename_i heq
+          exact (i.2 heq).elim
+        · rfl
+      have hupdatedProduct :
+          (∏ i : I,
+            (Function.update laws selected
+              selectedLaw i).mass
+                (tuple i)) =
+            selectedLaw.mass (tuple selected) *
+              ∏ i : {i : I // i ≠ selected},
+                (laws i.1).mass (tuple i.1) := by
+        rw [Fintype.prod_eq_mul_prod_subtype_ne _ selected]
+        rw [show
+          Function.update laws selected
+              selectedLaw selected = selectedLaw by
+              simp [Function.update], hrest]
+      rw [fintypePi_mass
+          (Function.update laws selected selectedLaw) tuple,
+        hupdatedProduct,
+        mass_conditionOnFiber (laws selected) id value
+          selectedLaw hselected]
+      change
+        (if tuple selected = value then
+            ((laws selected).mass (tuple selected) *
+              ∏ i : {i : I // i ≠ selected},
+                (laws i.1).mass (tuple i.1)) /
+                  (laws selected).eventMass selectedEvent
+          else 0) =
+          (if tuple selected = value then
+              (laws selected).mass (tuple selected) /
+                (laws selected).eventMass selectedEvent
+            else 0) *
+              ∏ i : {i : I // i ≠ selected},
+                (laws i.1).mass (tuple i.1)
+      by_cases heq : tuple selected = value
+      · simp [selectedEvent, heq, div_mul_eq_mul_div]
+      · simp [heq]
+
+end IndependentTables
+
+end FiniteLaw

--- a/EconCSLib/Math/Probability/FiniteLaw/Conditioning.lean
+++ b/EconCSLib/Math/Probability/FiniteLaw/Conditioning.lean
@@ -118,6 +118,16 @@ private lemma conditionOnFiber_eq_none_iff [DecidableEq β]
         (fun sample => decide (observe sample = value)) = 0 := by
   exact condition?_eq_none_iff law _
 
+private lemma eventMass_ne_zero_of_conditionOnFiber_eq_some [DecidableEq β]
+    (law : FiniteLaw α) (observe : α → β) (value : β)
+    {conditioned : FiniteLaw α}
+    (hconditioned : law.conditionOnFiber observe value = some conditioned) :
+    law.eventMass (fun sample => decide (observe sample = value)) ≠ 0 := by
+  intro hzero
+  have hnone := (conditionOnFiber_eq_none_iff law observe value).mpr hzero
+  rw [hconditioned] at hnone
+  exact Option.some_ne_none _ hnone
+
 /-- A zero-mass fiber has no posterior. -/
 lemma conditionOnFiber_of_impossible [DecidableEq β]
     (law : FiniteLaw α) (observe : α → β) (value : β)
@@ -143,14 +153,8 @@ theorem mass_conditionOnFiber [DecidableEq α] [DecidableEq β]
           law.eventMass
             (fun sample => decide (observe sample = value))
       else 0 := by
-  have hnonzero :
-      law.eventMass
-        (fun sample => decide (observe sample = value)) ≠ 0 := by
-    intro hzero
-    have hnone :=
-      (conditionOnFiber_eq_none_iff law observe value).mpr hzero
-    rw [hconditioned] at hnone
-    exact Option.some_ne_none _ hnone
+  have hnonzero :=
+    eventMass_ne_zero_of_conditionOnFiber_eq_some law observe value hconditioned
   have htotal :
       totalWeight
           (restrictAtoms law
@@ -241,134 +245,107 @@ end Fibers
 
 section IndependentTables
 
+variable {I : Type*} [Fintype I] [LinearOrder I] {X : I → Type uα}
+
+-- An event on one coordinate has exactly its marginal probability.
+private lemma eventMass_fintypePi_apply
+    (laws : (i : I) → FiniteLaw (X i)) (selected : I)
+    (event : X selected → Bool) :
+    (fintypePi laws).eventMass (fun tuple => event (tuple selected)) =
+      (laws selected).eventMass event := by
+  have hmarginal := (fintypePi_map_apply laws selected).eventMass event
+  simpa only [eventMass_map, Function.comp_def] using hmarginal
+
+variable [∀ i, DecidableEq (X i)] [DecidableEq ((i : I) → X i)]
+variable (laws : (i : I) → FiniteLaw (X i)) (selected : I)
+
+-- Updating one factor leaves the product over all other coordinates unchanged.
+private lemma mass_fintypePi_update (selectedLaw : FiniteLaw (X selected))
+    (tuple : (i : I) → X i) :
+    (fintypePi (Function.update laws selected selectedLaw)).mass tuple =
+      selectedLaw.mass (tuple selected) *
+        ∏ i : {i : I // i ≠ selected}, (laws i.1).mass (tuple i.1) := by
+  rw [fintypePi_mass, Fintype.prod_eq_mul_prod_subtype_ne _ selected]
+  simp only [Function.update_self]
+  congr 1
+  apply Finset.prod_congr rfl
+  intro i _
+  rw [Function.update_of_ne i.2]
+
+section PosteriorMass
+
+variable (value : X selected) (selectedLaw : FiniteLaw (X selected))
+variable (productLaw : FiniteLaw ((i : I) → X i))
+variable (hselected : (laws selected).conditionOnFiber id value = some selectedLaw)
+variable (hproduct :
+  (fintypePi laws).conditionOnFiber (fun tuple => tuple selected) value = some productLaw)
+
+include hselected hproduct
+
+-- Successful conditioning replaces precisely the selected factor.
+private lemma conditioned_fintypePi_equivalent :
+    productLaw.Equivalent (fintypePi (Function.update laws selected selectedLaw)) := by
+  apply Equivalent.of_mass_eq
+  intro tuple
+  rw [mass_conditionOnFiber (fintypePi laws) (fun tuple => tuple selected)
+      value productLaw hproduct tuple,
+    fintypePi_mass,
+    eventMass_fintypePi_apply laws selected (fun outcome => decide (outcome = value)),
+    Fintype.prod_eq_mul_prod_subtype_ne _ selected,
+    mass_fintypePi_update,
+    mass_conditionOnFiber (laws selected) id value selectedLaw hselected]
+  change
+    (if tuple selected = value then
+        ((laws selected).mass (tuple selected) *
+          ∏ i : {i : I // i ≠ selected}, (laws i.1).mass (tuple i.1)) /
+            (laws selected).eventMass (fun outcome => decide (outcome = value))
+      else 0) =
+      (if tuple selected = value then
+          (laws selected).mass (tuple selected) /
+            (laws selected).eventMass (fun outcome => decide (outcome = value))
+        else 0) *
+          ∏ i : {i : I // i ≠ selected}, (laws i.1).mass (tuple i.1)
+  by_cases heq : tuple selected = value
+  · simp [heq, div_mul_eq_mul_div]
+  · simp [heq]
+
+end PosteriorMass
+
 /-- Conditioning one coordinate of an independent finite table preserves
 independence and updates exactly that coordinate, up to sparse-presentation
 equivalence. -/
-theorem fintypePi_conditionOnFiber_apply
-    {I : Type*} [Fintype I] [LinearOrder I]
-    {X : I → Type uα}
-    [∀ i, DecidableEq (X i)]
-    [DecidableEq ((i : I) → X i)]
-    (laws : (i : I) → FiniteLaw (X i))
-    (selected : I) (value : X selected) :
+theorem fintypePi_conditionOnFiber_apply (value : X selected) :
     Option.Rel Equivalent
       ((fintypePi laws).conditionOnFiber
         (fun tuple => tuple selected) value)
       ((laws selected).conditionOnFiber id value |>.map
         (fun selectedLaw =>
-          fintypePi
-            (Function.update laws selected selectedLaw))) := by
-  classical
-  let selectedEvent : X selected → Bool :=
-    fun outcome => decide (outcome = value)
-  have heventMass :
-      (fintypePi laws).eventMass
-          (fun tuple => decide (tuple selected = value)) =
-        (laws selected).eventMass selectedEvent := by
-    have hmarginal :=
-      (fintypePi_map_apply laws selected).eventMass selectedEvent
-    rw [eventMass_map] at hmarginal
-    simpa [selectedEvent, Function.comp_def] using hmarginal
+          fintypePi (Function.update laws selected selectedLaw))) := by
+  have heventMass := eventMass_fintypePi_apply laws selected
+    (fun outcome => decide (outcome = value))
   cases hselected : (laws selected).conditionOnFiber id value with
   | none =>
-      have hselectedZero :
-          (laws selected).eventMass selectedEvent = 0 := by
-        exact (conditionOnFiber_eq_none_iff
-          (laws selected) id value).1 hselected
-      have hproductZero :
-          (fintypePi laws).eventMass
-            (fun tuple => decide (tuple selected = value)) = 0 := by
-        rw [heventMass, hselectedZero]
       have hproduct :
-          (fintypePi laws).conditionOnFiber
-              (fun tuple => tuple selected) value = none :=
-        (conditionOnFiber_eq_none_iff
-          (fintypePi laws) (fun tuple => tuple selected) value).2
-          hproductZero
+          (fintypePi laws).conditionOnFiber (fun tuple => tuple selected) value = none := by
+        apply (conditionOnFiber_eq_none_iff _ _ _).2
+        rw [heventMass]
+        exact (conditionOnFiber_eq_none_iff (laws selected) id value).1 hselected
       rw [hproduct]
-      simp only [Option.map]
       exact Option.Rel.none
   | some selectedLaw =>
-      have hselectedNonzero :
-          (laws selected).eventMass selectedEvent ≠ 0 := by
-        intro hzero
-        have hnone := (conditionOnFiber_eq_none_iff
-          (laws selected) id value).2 hzero
-        rw [hselected] at hnone
-        exact Option.some_ne_none _ hnone
-      have hproductNonzero :
-          (fintypePi laws).eventMass
-              (fun tuple => decide (tuple selected = value)) ≠ 0 := by
-        rw [heventMass]
-        exact hselectedNonzero
+      have hnonzero :=
+        eventMass_ne_zero_of_conditionOnFiber_eq_some (laws selected) id value hselected
       have hproductSome :
-          (fintypePi laws).conditionOnFiber
-              (fun tuple => tuple selected) value ≠ none := by
+          (fintypePi laws).conditionOnFiber (fun tuple => tuple selected) value ≠ none := by
         intro hnone
-        exact hproductNonzero
-          ((conditionOnFiber_eq_none_iff
-            (fintypePi laws) (fun tuple => tuple selected) value).1
-            hnone)
-      obtain ⟨productLaw, hproduct⟩ :=
-        Option.ne_none_iff_exists'.mp hproductSome
+        apply hnonzero
+        simpa only [id_eq] using
+          heventMass.symm.trans ((conditionOnFiber_eq_none_iff _ _ _).1 hnone)
+      obtain ⟨productLaw, hproduct⟩ := Option.ne_none_iff_exists'.mp hproductSome
       rw [hproduct]
-      simp only [Option.map]
-      apply Option.Rel.some
-      apply Equivalent.of_mass_eq
-      intro tuple
-      rw [mass_conditionOnFiber
-          (fintypePi laws) (fun tuple => tuple selected) value
-          productLaw hproduct tuple,
-        fintypePi_mass, heventMass,
-        Fintype.prod_eq_mul_prod_subtype_ne _ selected]
-      have hrest :
-          (∏ i : {i : I // i ≠ selected},
-            (Function.update laws selected
-              selectedLaw i.1).mass
-                (tuple i.1)) =
-            ∏ i : {i : I // i ≠ selected},
-              (laws i.1).mass (tuple i.1) := by
-        apply Finset.prod_congr rfl
-        intro i _
-        unfold Function.update
-        split
-        · rename_i heq
-          exact (i.2 heq).elim
-        · rfl
-      have hupdatedProduct :
-          (∏ i : I,
-            (Function.update laws selected
-              selectedLaw i).mass
-                (tuple i)) =
-            selectedLaw.mass (tuple selected) *
-              ∏ i : {i : I // i ≠ selected},
-                (laws i.1).mass (tuple i.1) := by
-        rw [Fintype.prod_eq_mul_prod_subtype_ne _ selected]
-        rw [show
-          Function.update laws selected
-              selectedLaw selected = selectedLaw by
-              simp [Function.update], hrest]
-      rw [fintypePi_mass
-          (Function.update laws selected selectedLaw) tuple,
-        hupdatedProduct,
-        mass_conditionOnFiber (laws selected) id value
-          selectedLaw hselected]
-      change
-        (if tuple selected = value then
-            ((laws selected).mass (tuple selected) *
-              ∏ i : {i : I // i ≠ selected},
-                (laws i.1).mass (tuple i.1)) /
-                  (laws selected).eventMass selectedEvent
-          else 0) =
-          (if tuple selected = value then
-              (laws selected).mass (tuple selected) /
-                (laws selected).eventMass selectedEvent
-            else 0) *
-              ∏ i : {i : I // i ≠ selected},
-                (laws i.1).mass (tuple i.1)
-      by_cases heq : tuple selected = value
-      · simp [selectedEvent, heq, div_mul_eq_mul_div]
-      · simp [heq]
+      exact Option.Rel.some
+        (conditioned_fintypePi_equivalent laws selected value selectedLaw productLaw
+          hselected hproduct)
 
 end IndependentTables
 

--- a/EconCSLib/Math/Probability/FiniteLaw/Core.lean
+++ b/EconCSLib/Math/Probability/FiniteLaw/Core.lean
@@ -382,7 +382,7 @@ lemma mass_pure [DecidableEq α] (outcome target : α) :
 /-- Mapping along an equivalence transports point masses through its unique
 preimage. -/
 lemma mass_map_equiv [DecidableEq α] [DecidableEq β]
-  (law : FiniteLaw α) (equivalence : α ≃ β) (target : β) :
+    (law : FiniteLaw α) (equivalence : α ≃ β) (target : β) :
     (law.map equivalence).mass target =
       law.mass (equivalence.symm target) := by
   unfold mass eventMass
@@ -458,7 +458,7 @@ end Mass
 
 section Expectation
 
-variable {α β γ : Type*}
+variable {α β : Type*}
 
 private def atomsMass [DecidableEq α]
     (atoms : List (α × ℚ≥0)) (outcome : α) : ℚ≥0 :=
@@ -666,7 +666,7 @@ end Expectation
 
 section Equivalence
 
-variable {α β γ : Type*}
+variable {α β : Type*}
 
 lemma Equivalent.refl (law : FiniteLaw α) : law.Equivalent law :=
   fun _ => rfl
@@ -832,7 +832,7 @@ end Equivalence
 
 section Normalization
 
-variable {α β γ : Type*}
+variable {α : Type*}
 
 /-- Dividing all weights by a fixed scalar divides the total weight by that
 scalar. -/
@@ -868,6 +868,22 @@ def normalize (atoms : List (α × ℚ≥0))
           (atom.1, atom.2 / totalWeight atoms)) = 1
     exact totalWeight_div atoms hnonzero
 
+private lemma sum_indicator_div [DecidableEq α]
+    (raw : List (α × ℚ≥0)) (divisor : ℚ≥0) (outcome : α) :
+    (raw.map fun atom =>
+      if decide (atom.1 = outcome) then atom.2 / divisor else 0).sum =
+      (raw.map fun atom =>
+        if atom.1 = outcome then atom.2 else 0).sum / divisor := by
+  induction raw with
+  | nil => simp
+  | cons atom raw ih =>
+      rcases atom with ⟨candidate, weight⟩
+      simp only [List.map_cons, List.sum_cons]
+      rw [ih]
+      by_cases heq : candidate = outcome
+      · simp [heq, add_div]
+      · simp [heq]
+
 /-- Point mass after normalization is the raw point weight divided by the
 raw total weight. -/
 theorem mass_normalize [DecidableEq α]
@@ -879,22 +895,7 @@ theorem mass_normalize [DecidableEq α]
         totalWeight atoms := by
   unfold normalize mass eventMass
   simp only [List.map_map, Function.comp_def]
-  have sum_indicator_div
-      (raw : List (α × ℚ≥0)) (divisor : ℚ≥0) :
-      (raw.map fun atom =>
-        if decide (atom.1 = outcome) then atom.2 / divisor else 0).sum =
-        (raw.map fun atom =>
-          if atom.1 = outcome then atom.2 else 0).sum / divisor := by
-    induction raw with
-    | nil => simp
-    | cons atom raw ih =>
-        rcases atom with ⟨candidate, weight⟩
-        simp only [List.map_cons, List.sum_cons]
-        rw [ih]
-        by_cases heq : candidate = outcome
-        · simp [heq, add_div]
-        · simp [heq]
-  exact sum_indicator_div atoms (totalWeight atoms)
+  exact sum_indicator_div atoms (totalWeight atoms) outcome
 
 /-- Normalize a nonzero finite weighted list.
 

--- a/EconCSLib/Math/Probability/FiniteLaw/Core.lean
+++ b/EconCSLib/Math/Probability/FiniteLaw/Core.lean
@@ -1,0 +1,916 @@
+/-
+Copyright (c) 2026 EconCSLib contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+
+import Mathlib.Data.NNRat.BigOperators
+import Mathlib.Data.NNRat.Lemmas
+
+/-!
+# Finite exact probability laws
+
+`FiniteLaw α` is the executable probability representation used by finite
+EconCSLib models.  A law is a finite list of outcomes with nonnegative rational
+weights whose total is one.  Repeated outcomes are intentional: construction,
+mapping, and binding never need an ambient `Fintype α` or `DecidableEq α`.
+
+The list is a sparse presentation, not the semantic equality of laws. When
+outcomes are decidably equal, `mass` adds every occurrence of an outcome.
+`Equivalent` instead compares all exact rational expectations, so semantic
+comparison does not require equality on the outcome carrier.
+
+## Main definitions
+
+* `FiniteLaw.pure`, `FiniteLaw.map`, and `FiniteLaw.bind`;
+* `FiniteLaw.HasPositiveAtom` for presentation-independent reachability
+  arguments that do not require equality on the outcome type;
+* `FiniteLaw.eventMass` and `FiniteLaw.mass`;
+* `FiniteLaw.normalize?` for validated normalization of a nonzero weighted
+  list;
+* `FiniteLaw.expectRat` for exact rational expected values.
+
+The executable definitions use neither classical choice nor infinite sums.
+-/
+
+open BigOperators
+
+universe uα uβ uγ
+
+/-- A finite, exact probability law represented by rationally weighted atoms.
+
+Repeated outcomes are allowed.  This keeps `map` and `bind` executable without
+requiring equality or a finite enumeration of the ambient outcome type. -/
+structure FiniteLaw (α : Type uα) where
+  /-- Sparse weighted occurrences. -/
+  atoms : List (α × ℚ≥0)
+  /-- The occurrence weights sum to one. -/
+  normalized : (atoms.map Prod.snd).sum = 1
+
+namespace FiniteLaw
+
+/-! ## Point laws and composition -/
+
+section Composition
+
+variable {α β γ : Type*}
+
+/-- Two finite laws are equal when their weighted atom lists are equal.
+
+The normalization field is proof-valued, so no separate proof equality is
+required. -/
+@[ext]
+lemma ext {left right : FiniteLaw α}
+    (hatoms : left.atoms = right.atoms) : left = right := by
+  cases left
+  cases right
+  cases hatoms
+  rfl
+
+/-- The total weight of a finite atom list. -/
+def totalWeight (atoms : List (α × ℚ≥0)) : ℚ≥0 :=
+  (atoms.map Prod.snd).sum
+
+@[simp]
+lemma totalWeight_atoms (law : FiniteLaw α) :
+    totalWeight law.atoms = 1 :=
+  law.normalized
+
+/-- The point law concentrated at one outcome. -/
+def pure (outcome : α) : FiniteLaw α where
+  atoms := [(outcome, 1)]
+  normalized := by simp
+
+@[simp]
+lemma pure_atoms (outcome : α) :
+    (pure outcome).atoms = [(outcome, 1)] :=
+  rfl
+
+/-- An outcome occurs with positive weight in a finite-law presentation.
+
+This predicate deliberately quantifies over occurrences rather than requiring
+a duplicate-free support. It is usable without `DecidableEq α` and is stable
+under the executable `map` and `bind` operations below. -/
+def HasPositiveAtom (law : FiniteLaw α) (outcome : α) : Prop :=
+  ∃ weight, (outcome, weight) ∈ law.atoms ∧ weight ≠ 0
+
+@[simp]
+lemma hasPositiveAtom_pure_iff (outcome target : α) :
+    (pure outcome).HasPositiveAtom target ↔ target = outcome := by
+  constructor
+  · rintro ⟨weight, hmem, hweight⟩
+    simp only [pure_atoms, List.mem_singleton] at hmem
+    exact congrArg Prod.fst hmem
+  · rintro rfl
+    exact ⟨1, by simp, one_ne_zero⟩
+
+private lemma exists_atom_ne_zero_of_totalWeight_eq_one
+    (atoms : List (α × ℚ≥0)) (hnormalized : totalWeight atoms = 1) :
+    ∃ atom ∈ atoms, atom.2 ≠ 0 := by
+  induction atoms with
+  | nil => simp [totalWeight] at hnormalized
+  | cons atom atoms ih =>
+      by_cases hweight : atom.2 = 0
+      · have htail : totalWeight atoms = 1 := by
+          simpa [totalWeight, hweight] using hnormalized
+        obtain ⟨target, htarget, hpositive⟩ := ih htail
+        exact ⟨target, by simp [htarget], hpositive⟩
+      · exact ⟨atom, by simp, hweight⟩
+
+/-- Every normalized finite law has at least one positive atom. -/
+lemma exists_hasPositiveAtom (law : FiniteLaw α) :
+    ∃ outcome, law.HasPositiveAtom outcome := by
+  obtain ⟨atom, hatom, hweight⟩ :=
+    exists_atom_ne_zero_of_totalWeight_eq_one law.atoms
+      law.normalized
+  exact ⟨atom.1, atom.2, hatom, hweight⟩
+
+/-- Push a finite law forward along a function. -/
+def map (f : α → β) (law : FiniteLaw α) : FiniteLaw β where
+  atoms := law.atoms.map fun atom => (f atom.1, atom.2)
+  normalized := by
+    simpa [List.map_map, Function.comp_def] using law.normalized
+
+@[simp]
+lemma map_atoms (f : α → β) (law : FiniteLaw α) :
+    (map f law).atoms =
+      law.atoms.map fun atom => (f atom.1, atom.2) :=
+  rfl
+
+lemma hasPositiveAtom_map_iff (f : α → β) (law : FiniteLaw α)
+    (target : β) :
+    (law.map f).HasPositiveAtom target ↔
+      ∃ source, law.HasPositiveAtom source ∧ f source = target := by
+  constructor
+  · rintro ⟨weight, hmem, hweight⟩
+    rw [map_atoms, List.mem_map] at hmem
+    obtain ⟨atom, hatom, heq⟩ := hmem
+    refine ⟨atom.1, ⟨atom.2, hatom, ?_⟩, ?_⟩
+    · intro hzero
+      exact hweight ((congrArg Prod.snd heq).symm.trans hzero)
+    · simpa only using congrArg Prod.fst heq
+  · rintro ⟨source, ⟨weight, hmem, hweight⟩, rfl⟩
+    refine ⟨weight, ?_, hweight⟩
+    rw [map_atoms, List.mem_map]
+    exact ⟨(source, weight), hmem, rfl⟩
+
+/-- Scaling every atom scales the total weight by the same factor. -/
+private lemma totalWeight_map_mul
+    (weight : ℚ≥0) (atoms : List (β × ℚ≥0)) :
+    totalWeight
+        (atoms.map fun atom => (atom.1, weight * atom.2)) =
+      weight * totalWeight atoms := by
+  simp only [totalWeight, List.map_map]
+  induction atoms with
+  | nil => simp
+  | cons atom atoms ih =>
+      simp [ih, mul_add]
+
+/-- Total weight distributes over list append. -/
+private lemma totalWeight_append
+    (left right : List (α × ℚ≥0)) :
+    totalWeight (left ++ right) =
+      totalWeight left + totalWeight right := by
+  simp [totalWeight, List.map_append]
+
+/-- Binding over a list of outer atoms preserves its total weight when every
+continuation law is normalized. -/
+private lemma totalWeight_flatMap
+    (atoms : List (α × ℚ≥0)) (next : α → FiniteLaw β) :
+    totalWeight
+        (atoms.flatMap fun atom =>
+          (next atom.1).atoms.map fun target =>
+            (target.1, atom.2 * target.2)) =
+      totalWeight atoms := by
+  induction atoms with
+  | nil => simp [totalWeight]
+  | cons atom atoms ih =>
+      rcases atom with ⟨outcome, weight⟩
+      simp only [List.flatMap_cons]
+      rw [totalWeight_append, totalWeight_map_mul, ih,
+        totalWeight_atoms, mul_one]
+      rfl
+
+/-- Sequential composition of finite laws.
+
+Every continuation atom is multiplied by the weight of the outer atom that
+reached it. The implementation is finite `List.flatMap`. -/
+def bind (law : FiniteLaw α) (next : α → FiniteLaw β) :
+    FiniteLaw β where
+  atoms :=
+    law.atoms.flatMap fun atom =>
+      (next atom.1).atoms.map fun target =>
+        (target.1, atom.2 * target.2)
+  normalized := by
+    change
+      totalWeight
+          (law.atoms.flatMap fun atom =>
+            (next atom.1).atoms.map fun target =>
+              (target.1, atom.2 * target.2)) = 1
+    exact (totalWeight_flatMap law.atoms next).trans law.normalized
+
+@[simp]
+lemma bind_atoms (law : FiniteLaw α) (next : α → FiniteLaw β) :
+    (bind law next).atoms =
+      law.atoms.flatMap fun atom =>
+        (next atom.1).atoms.map fun target =>
+          (target.1, atom.2 * target.2) :=
+  rfl
+
+@[simp]
+lemma pure_bind (outcome : α) (next : α → FiniteLaw β) :
+    (pure outcome).bind next = next outcome := by
+  apply FiniteLaw.ext
+  simp [bind_atoms]
+
+@[simp]
+lemma bind_pure (law : FiniteLaw α) :
+    law.bind pure = law := by
+  apply FiniteLaw.ext
+  simp [bind_atoms]
+
+lemma bind_bind (law : FiniteLaw α) (next : α → FiniteLaw β)
+    (final : β → FiniteLaw γ) :
+    (law.bind next).bind final =
+      law.bind fun outcome => (next outcome).bind final := by
+  apply FiniteLaw.ext
+  simp only [bind_atoms]
+  induction law.atoms with
+  | nil => rfl
+  | cons outer outers ih =>
+      rcases outer with ⟨outcome, outerWeight⟩
+      simp only [List.flatMap_cons]
+      rw [List.flatMap_append, ih]
+      congr 1
+      induction (next outcome).atoms with
+      | nil => rfl
+      | cons inner inners ihInner =>
+          rcases inner with ⟨target, innerWeight⟩
+          simp only [List.map_cons, List.flatMap_cons, List.map_append]
+          rw [ihInner]
+          simp [mul_assoc]
+
+lemma map_eq_bind_pure_comp (f : α → β) (law : FiniteLaw α) :
+    law.map f = law.bind (pure ∘ f) := by
+  apply FiniteLaw.ext
+  simp only [map_atoms, bind_atoms]
+  induction law.atoms with
+  | nil => rfl
+  | cons atom atoms ih =>
+      rcases atom with ⟨outcome, weight⟩
+      simp [ih]
+
+lemma pure_map (f : α → β) (outcome : α) :
+    (pure outcome).map f = pure (f outcome) := by
+  apply FiniteLaw.ext
+  simp [map_atoms]
+
+lemma map_bind (law : FiniteLaw α) (next : α → FiniteLaw β)
+    (f : β → γ) :
+    (law.bind next).map f =
+      law.bind fun outcome => (next outcome).map f := by
+  rw [map_eq_bind_pure_comp, bind_bind]
+  congr
+  funext outcome
+  rw [← map_eq_bind_pure_comp]
+
+lemma bind_map (law : FiniteLaw α) (f : α → β)
+    (next : β → FiniteLaw γ) :
+    (law.map f).bind next =
+      law.bind (next ∘ f) := by
+  rw [map_eq_bind_pure_comp, bind_bind]
+  congr
+  funext outcome
+  simp
+
+lemma map_comp (f : α → β) (law : FiniteLaw α) (g : β → γ) :
+    (law.map f).map g = law.map (g ∘ f) := by
+  apply FiniteLaw.ext
+  simp [map_atoms, List.map_map, Function.comp_def]
+
+lemma map_id (law : FiniteLaw α) : law.map id = law := by
+  apply FiniteLaw.ext
+  simp [map_atoms]
+
+/-- Pushforward along a type equivalence is an equivalence of finite-law
+presentations. -/
+def mapEquiv (equivalence : α ≃ β) : FiniteLaw α ≃ FiniteLaw β where
+  toFun := map equivalence
+  invFun := map equivalence.symm
+  left_inv law := by
+    rw [map_comp]
+    have hcomp : (equivalence.symm : β → α) ∘ equivalence = id := by
+      funext outcome
+      exact equivalence.symm_apply_apply outcome
+    rw [hcomp, map_id]
+  right_inv law := by
+    rw [map_comp]
+    have hcomp : (equivalence : α → β) ∘ equivalence.symm = id := by
+      funext outcome
+      exact equivalence.apply_symm_apply outcome
+    rw [hcomp, map_id]
+
+lemma hasPositiveAtom_bind_iff (law : FiniteLaw α)
+    (next : α → FiniteLaw β) (target : β) :
+    (law.bind next).HasPositiveAtom target ↔
+      ∃ source, law.HasPositiveAtom source ∧
+        (next source).HasPositiveAtom target := by
+  constructor
+  · rintro ⟨weight, hmem, hweight⟩
+    rw [bind_atoms, List.mem_flatMap] at hmem
+    obtain ⟨outer, houter, hmem⟩ := hmem
+    rw [List.mem_map] at hmem
+    obtain ⟨inner, hinner, heq⟩ := hmem
+    rcases outer with ⟨source, outerWeight⟩
+    rcases inner with ⟨innerTarget, innerWeight⟩
+    have htarget : innerTarget = target := by
+      simpa only using congrArg Prod.fst heq
+    subst innerTarget
+    have hproduct : outerWeight * innerWeight = weight := by
+      simpa only using congrArg Prod.snd heq
+    have houterWeight : outerWeight ≠ 0 := by
+      intro hzero
+      apply hweight
+      rw [← hproduct, hzero, zero_mul]
+    have hinnerWeight : innerWeight ≠ 0 := by
+      intro hzero
+      apply hweight
+      rw [← hproduct, hzero, mul_zero]
+    exact
+      ⟨source, ⟨outerWeight, houter, houterWeight⟩,
+        innerWeight, hinner, hinnerWeight⟩
+  · rintro
+      ⟨source, ⟨outerWeight, houter, houterWeight⟩,
+        innerWeight, hinner, hinnerWeight⟩
+    refine ⟨outerWeight * innerWeight, ?_, mul_ne_zero houterWeight hinnerWeight⟩
+    rw [bind_atoms, List.mem_flatMap]
+    refine ⟨(source, outerWeight), houter, ?_⟩
+    rw [List.mem_map]
+    exact ⟨(target, innerWeight), hinner, rfl⟩
+
+end Composition
+
+/-! ## Event and point masses -/
+
+section Mass
+
+/-- Total mass of an executable Boolean event. -/
+def eventMass (law : FiniteLaw α) (event : α → Bool) : ℚ≥0 :=
+  (law.atoms.map fun atom =>
+    if event atom.1 then atom.2 else 0).sum
+
+lemma eventMass_map (law : FiniteLaw α) (f : α → β)
+    (event : β → Bool) :
+    (law.map f).eventMass event =
+      law.eventMass (event ∘ f) := by
+  unfold eventMass
+  rw [map_atoms, List.map_map]
+  apply congrArg List.sum
+  apply List.map_congr_left
+  intro atom _
+  rfl
+
+/-- Total mass assigned to one outcome.  Equality is requested only for this
+observation; it is not needed to construct the law. -/
+def mass [DecidableEq α] (law : FiniteLaw α) (outcome : α) : ℚ≥0 :=
+  eventMass law fun candidate => decide (candidate = outcome)
+
+@[simp]
+lemma mass_pure [DecidableEq α] (outcome target : α) :
+    (pure outcome).mass target = if outcome = target then 1 else 0 := by
+  simp [mass, eventMass, pure]
+
+/-- Mapping along an equivalence transports point masses through its unique
+preimage. -/
+lemma mass_map_equiv [DecidableEq α] [DecidableEq β]
+  (law : FiniteLaw α) (equivalence : α ≃ β) (target : β) :
+    (law.map equivalence).mass target =
+      law.mass (equivalence.symm target) := by
+  unfold mass eventMass
+  rw [map_atoms, List.map_map]
+  apply congrArg List.sum
+  apply List.map_congr_left
+  intro atom _
+  simp [equivalence.eq_symm_apply]
+
+/-- Point mass of a finite bind is the finite weighted sum of continuation
+point masses. -/
+lemma mass_bind [DecidableEq β]
+    (law : FiniteLaw α) (next : α → FiniteLaw β) (target : β) :
+    (law.bind next).mass target =
+      (law.atoms.map fun atom =>
+        atom.2 * (next atom.1).mass target).sum := by
+  unfold mass eventMass
+  rw [bind_atoms]
+  induction law.atoms with
+  | nil => simp
+  | cons atom atoms ih =>
+      rcases atom with ⟨outcome, weight⟩
+      simp only [List.flatMap_cons, List.map_append, List.sum_append,
+        List.map_cons, List.sum_cons]
+      rw [ih]
+      congr 1
+      simp only [List.map_map, Function.comp_def]
+      induction (next outcome).atoms with
+      | nil => simp
+      | cons inner inners ihInner =>
+          rcases inner with ⟨innerOutcome, innerWeight⟩
+          simp only [List.map_cons, List.sum_cons]
+          rw [ihInner]
+          by_cases heq : innerOutcome = target
+          · simp [heq, mul_add]
+          · simp [heq]
+
+/-- An outcome absent from all positive atoms has zero total mass. -/
+lemma mass_eq_zero_of_not_hasPositiveAtom [DecidableEq α]
+    (law : FiniteLaw α) (outcome : α)
+    (habsent : ¬ law.HasPositiveAtom outcome) :
+    law.mass outcome = 0 := by
+  unfold mass eventMass
+  apply List.sum_eq_zero
+  intro weight hweight
+  rw [List.mem_map] at hweight
+  obtain ⟨atom, hatom, rfl⟩ := hweight
+  rcases atom with ⟨candidate, atomWeight⟩
+  by_cases heq : candidate = outcome
+  · subst candidate
+    simp only [decide_true, ↓reduceIte]
+    by_contra hnonzero
+    exact habsent ⟨atomWeight, hatom, hnonzero⟩
+  · simp [heq]
+
+/-- Point mass is independent of the particular equality decision procedure
+used to compute it. -/
+lemma mass_decidableEq_irrel
+    (first second : DecidableEq α)
+    (law : FiniteLaw α) (outcome : α) :
+    @mass α first law outcome = @mass α second law outcome := by
+  unfold mass eventMass
+  apply congrArg List.sum
+  apply List.map_congr_left
+  intro atom _
+  by_cases heq : atom.1 = outcome
+  · simp [heq]
+  · simp [heq]
+
+end Mass
+
+/-! ## Exact expectations -/
+
+section Expectation
+
+variable {α β γ : Type*}
+
+private def atomsMass [DecidableEq α]
+    (atoms : List (α × ℚ≥0)) (outcome : α) : ℚ≥0 :=
+  (atoms.map fun atom =>
+    if decide (atom.1 = outcome) then atom.2 else 0).sum
+
+/-- Two sparse presentations describe the same finite law when every exact
+rational observable has the same expectation.
+
+Quantifying over observables avoids a global `DecidableEq` requirement while
+still identifying presentations that differ only by repeated or reordered
+atoms. -/
+def Equivalent (left right : FiniteLaw α) : Prop :=
+  ∀ value : α → ℚ,
+    (left.atoms.map fun atom => (atom.2 : ℚ) * value atom.1).sum =
+      (right.atoms.map fun atom => (atom.2 : ℚ) * value atom.1).sum
+
+/-- Exact rational expectation of a rational-valued observable. -/
+def expectRat (law : FiniteLaw α) (value : α → ℚ) : ℚ :=
+  (law.atoms.map fun atom => (atom.2 : ℚ) * value atom.1).sum
+
+private lemma atomsExpectation_eq_finsetSum [DecidableEq α]
+    (atoms : List (α × ℚ≥0)) (support : Finset α)
+    (hmem : ∀ atom ∈ atoms, atom.1 ∈ support)
+    (value : α → ℚ) :
+    (atoms.map fun atom => (atom.2 : ℚ) * value atom.1).sum =
+      ∑ outcome ∈ support,
+        (atomsMass atoms outcome : ℚ) * value outcome := by
+  induction atoms with
+  | nil => simp [atomsMass]
+  | cons atom atoms ih =>
+      rcases atom with ⟨outcome, weight⟩
+      have houtcome : outcome ∈ support :=
+        hmem (outcome, weight) (by simp)
+      have htail : ∀ atom ∈ atoms, atom.1 ∈ support := by
+        intro atom hatom
+        exact hmem atom (List.mem_cons_of_mem _ hatom)
+      simp only [List.map_cons, List.sum_cons]
+      rw [ih htail]
+      simp only [atomsMass, List.map_cons, List.sum_cons,
+        NNRat.cast_add, add_mul]
+      rw [Finset.sum_add_distrib]
+      congr 1
+      rw [Finset.sum_eq_single outcome]
+      · simp
+      · intro other _ hne
+        simp [hne.symm]
+      · intro hnot
+        exact (hnot houtcome).elim
+
+lemma equivalent_iff_expectRat {left right : FiniteLaw α} :
+    left.Equivalent right ↔
+      ∀ value, left.expectRat value = right.expectRat value :=
+  Iff.rfl
+
+@[simp]
+lemma expectRat_pure (outcome : α) (value : α → ℚ) :
+    (pure outcome).expectRat value = value outcome := by
+  simp [expectRat]
+
+lemma expectRat_map (f : α → β) (law : FiniteLaw α)
+    (value : β → ℚ) :
+    (law.map f).expectRat value = law.expectRat (value ∘ f) := by
+  simp [expectRat, map_atoms, List.map_map, Function.comp_def]
+
+private lemma expectRat_indicator (law : FiniteLaw α)
+    (event : α → Bool) :
+    law.expectRat (fun outcome => if event outcome then 1 else 0) =
+      (law.eventMass event : ℚ) := by
+  unfold expectRat
+  let weights : List ℚ≥0 :=
+    law.atoms.map fun atom =>
+      if event atom.1 then atom.2 else 0
+  change
+    (law.atoms.map fun atom =>
+      (atom.2 : ℚ) * if event atom.1 then 1 else 0).sum =
+        (weights.sum : ℚ)
+  calc
+    (law.atoms.map fun atom =>
+        (atom.2 : ℚ) * if event atom.1 then 1 else 0).sum =
+        (List.map (NNRat.cast : ℚ≥0 → ℚ) weights).sum := by
+      unfold weights
+      rw [List.map_map]
+      apply congrArg List.sum
+      apply List.map_congr_left
+      intro atom _
+      by_cases hevent : event atom.1
+      · simp [hevent]
+      · simp [hevent]
+    _ = (weights.sum : ℚ) := by
+      simpa using
+        (map_list_sum (NNRat.castHom ℚ) weights).symm
+
+@[simp]
+lemma expectRat_const (law : FiniteLaw α) (constant : ℚ) :
+    law.expectRat (fun _ => constant) = constant := by
+  unfold expectRat
+  have hcast :
+      (law.atoms.map fun atom => (atom.2 : ℚ)).sum = 1 := by
+    calc
+      (law.atoms.map fun atom => (atom.2 : ℚ)).sum =
+          ((law.atoms.map Prod.snd).sum : ℚ) := by
+        simpa using
+          (map_list_sum (NNRat.castHom ℚ)
+            (law.atoms.map Prod.snd)).symm
+      _ = 1 := by rw [law.normalized]; norm_num
+  calc
+    (law.atoms.map fun atom => (atom.2 : ℚ) * constant).sum =
+        (law.atoms.map fun atom => (atom.2 : ℚ)).sum * constant := by
+      induction law.atoms with
+      | nil => simp
+      | cons atom atoms ih => simp [ih, add_mul]
+    _ = constant := by rw [hcast, one_mul]
+
+private lemma expectRat_scaledAtoms
+    (weight : ℚ≥0) (atoms : List (β × ℚ≥0))
+    (value : β → ℚ) :
+    (atoms.map fun atom =>
+        ((weight * atom.2 : ℚ≥0) : ℚ) * value atom.1).sum =
+      (weight : ℚ) *
+        (atoms.map fun atom => (atom.2 : ℚ) * value atom.1).sum := by
+  induction atoms with
+  | nil => simp
+  | cons atom atoms ih =>
+      simp only [List.map_cons, List.sum_cons, NNRat.cast_mul]
+      have ih' :
+          (atoms.map fun atom =>
+            (weight : ℚ) * (atom.2 : ℚ) * value atom.1).sum =
+            (weight : ℚ) *
+              (atoms.map fun atom =>
+                (atom.2 : ℚ) * value atom.1).sum := by
+        simpa only [NNRat.cast_mul] using ih
+      rw [ih', mul_add]
+      ring
+
+private lemma expectRat_bind_atoms
+    (atoms : List (α × ℚ≥0)) (next : α → FiniteLaw β)
+    (value : β → ℚ) :
+    (List.map (fun atom : β × ℚ≥0 => (atom.2 : ℚ) * value atom.1)
+        (atoms.flatMap fun atom =>
+          (next atom.1).atoms.map fun target =>
+            (target.1, atom.2 * target.2))).sum =
+      (atoms.map fun atom =>
+        (atom.2 : ℚ) * (next atom.1).expectRat value).sum := by
+  induction atoms with
+  | nil => simp
+  | cons atom atoms ih =>
+      rcases atom with ⟨outcome, weight⟩
+      simp only [List.flatMap_cons, List.map_append, List.sum_append,
+        List.map_cons, List.sum_cons]
+      have hscaled :
+          (List.map (fun atom : β × ℚ≥0 =>
+                (atom.2 : ℚ) * value atom.1)
+              (List.map (fun target =>
+                (target.1, weight * target.2))
+                (next outcome).atoms)).sum =
+            (weight : ℚ) * (next outcome).expectRat value := by
+        simpa only [List.map_map, Function.comp_def, expectRat] using
+          expectRat_scaledAtoms weight (next outcome).atoms value
+      rw [hscaled, ih]
+
+theorem expectRat_bind (law : FiniteLaw α)
+    (next : α → FiniteLaw β) (value : β → ℚ) :
+    (law.bind next).expectRat value =
+      law.expectRat fun outcome => (next outcome).expectRat value := by
+  unfold expectRat
+  rw [bind_atoms]
+  exact expectRat_bind_atoms law.atoms next value
+
+/-- Exact expectations depend only on an observable's values at positive
+atoms. -/
+lemma expectRat_congr_positive (law : FiniteLaw α)
+    {left right : α → ℚ}
+    (hcongr : ∀ outcome, law.HasPositiveAtom outcome →
+      left outcome = right outcome) :
+    law.expectRat left = law.expectRat right := by
+  unfold expectRat
+  congr 1
+  apply List.map_congr_left
+  intro atom hatom
+  rcases atom with ⟨outcome, weight⟩
+  by_cases hweight : weight = 0
+  · simp [hweight]
+  · rw [hcongr outcome ⟨weight, hatom, hweight⟩]
+
+/-- Binding pointwise equivalent continuations need only be checked at the
+positive atoms of the outer law. -/
+lemma bind_congr_positive (law : FiniteLaw α)
+    {left right : α → FiniteLaw β}
+    (hcongr : ∀ outcome, law.HasPositiveAtom outcome →
+      (left outcome).Equivalent (right outcome)) :
+    (law.bind left).Equivalent (law.bind right) := by
+  intro value
+  change
+    (law.bind left).expectRat value =
+      (law.bind right).expectRat value
+  rw [expectRat_bind, expectRat_bind]
+  apply expectRat_congr_positive law
+  intro outcome houtcome
+  exact hcongr outcome houtcome value
+
+end Expectation
+
+/-! ## Semantic equivalence -/
+
+section Equivalence
+
+variable {α β γ : Type*}
+
+lemma Equivalent.refl (law : FiniteLaw α) : law.Equivalent law :=
+  fun _ => rfl
+
+lemma Equivalent.symm {left right : FiniteLaw α}
+    (h : left.Equivalent right) : right.Equivalent left :=
+  fun value => (h value).symm
+
+lemma Equivalent.trans {first second third : FiniteLaw α}
+    (hfirst : first.Equivalent second)
+    (hsecond : second.Equivalent third) : first.Equivalent third :=
+  fun value => (hfirst value).trans (hsecond value)
+
+lemma Equivalent.of_eq {left right : FiniteLaw α}
+    (h : left = right) : left.Equivalent right := by
+  subst right
+  exact Equivalent.refl left
+
+/-- Pointwise equality of total outcome masses implies semantic equality,
+even when the sparse atom lists use different orders or duplicate outcomes. -/
+theorem Equivalent.of_mass_eq [DecidableEq α]
+    {left right : FiniteLaw α}
+    (hmass : ∀ outcome, left.mass outcome = right.mass outcome) :
+    left.Equivalent right := by
+  intro value
+  let support : Finset α :=
+    (left.atoms.map Prod.fst ++ right.atoms.map Prod.fst).toFinset
+  have hleft : ∀ atom ∈ left.atoms, atom.1 ∈ support := by
+    intro atom hatom
+    simp only [support, List.mem_toFinset, List.mem_append,
+      List.mem_map]
+    exact Or.inl ⟨atom, hatom, rfl⟩
+  have hright : ∀ atom ∈ right.atoms, atom.1 ∈ support := by
+    intro atom hatom
+    simp only [support, List.mem_toFinset, List.mem_append,
+      List.mem_map]
+    exact Or.inr ⟨atom, hatom, rfl⟩
+  change left.expectRat value = right.expectRat value
+  unfold expectRat
+  rw [atomsExpectation_eq_finsetSum left.atoms support hleft value,
+    atomsExpectation_eq_finsetSum right.atoms support hright value]
+  apply Finset.sum_congr rfl
+  intro outcome _
+  have hraw :
+      atomsMass left.atoms outcome = atomsMass right.atoms outcome := by
+    simpa [mass, eventMass, atomsMass] using hmass outcome
+  rw [hraw]
+
+lemma Equivalent.map {left right : FiniteLaw α}
+    (h : left.Equivalent right) (f : α → β) :
+    (left.map f).Equivalent (right.map f) := by
+  intro value
+  change (left.map f).expectRat value = (right.map f).expectRat value
+  rw [expectRat_map, expectRat_map]
+  exact h (value ∘ f)
+
+/-- Semantically equivalent finite laws assign the same exact mass to every
+executable Boolean event. -/
+lemma Equivalent.eventMass {left right : FiniteLaw α}
+    (h : left.Equivalent right) (event : α → Bool) :
+    left.eventMass event = right.eventMass event := by
+  apply NNRat.cast_injective (α := ℚ)
+  rw [← expectRat_indicator, ← expectRat_indicator]
+  exact (equivalent_iff_expectRat.mp h) _
+
+lemma Equivalent.bind {left right : FiniteLaw α}
+    (h : left.Equivalent right)
+    {leftNext rightNext : α → FiniteLaw β}
+    (hnext : ∀ outcome, (leftNext outcome).Equivalent (rightNext outcome)) :
+    (left.bind leftNext).Equivalent (right.bind rightNext) := by
+  intro value
+  change
+    (left.bind leftNext).expectRat value =
+      (right.bind rightNext).expectRat value
+  rw [expectRat_bind, expectRat_bind]
+  calc
+    left.expectRat (fun outcome => (leftNext outcome).expectRat value) =
+        right.expectRat (fun outcome => (leftNext outcome).expectRat value) :=
+      (equivalent_iff_expectRat.mp h) _
+    _ = right.expectRat (fun outcome => (rightNext outcome).expectRat value) := by
+      congr 1
+      funext outcome
+      exact (equivalent_iff_expectRat.mp (hnext outcome)) value
+
+private lemma scalar_mul_list_sum {δ : Type*}
+    (scalar : ℚ) (atoms : List δ) (f : δ → ℚ) :
+    scalar * (atoms.map f).sum =
+      (atoms.map fun atom => scalar * f atom).sum := by
+  induction atoms with
+  | nil => simp
+  | cons atom atoms ih =>
+      simp [ih, mul_add]
+
+private lemma list_double_sum_comm {δ ε : Type*}
+    (first : List δ) (second : List ε) (f : δ → ε → ℚ) :
+    (first.map fun a => (second.map fun b => f a b).sum).sum =
+      (second.map fun b => (first.map fun a => f a b).sum).sum := by
+  induction first with
+  | nil => simp
+  | cons a first ih =>
+      simp only [List.map_cons, List.sum_cons]
+      rw [ih, ← List.sum_map_add]
+
+/-- Independent finite draws may be interchanged without changing any exact
+rational observable.  The presentations can differ in atom order, so this is
+semantic equivalence rather than structural equality. -/
+theorem bind_comm_equivalent
+    (left : FiniteLaw α) (right : FiniteLaw β)
+    (next : α → β → FiniteLaw γ) :
+    (left.bind fun a => right.bind fun b => next a b).Equivalent
+      (right.bind fun b => left.bind fun a => next a b) := by
+  intro value
+  change
+    (left.bind fun a => right.bind fun b => next a b).expectRat value =
+      (right.bind fun b => left.bind fun a => next a b).expectRat value
+  rw [expectRat_bind, expectRat_bind]
+  simp only [expectRat_bind]
+  unfold expectRat
+  have weighted_double_sum_comm
+      (first : List (α × ℚ≥0)) (second : List (β × ℚ≥0))
+      (f : α → β → ℚ) :
+      (first.map fun a => (a.2 : ℚ) *
+          (second.map fun b => (b.2 : ℚ) * f a.1 b.1).sum).sum =
+        (second.map fun b => (b.2 : ℚ) *
+          (first.map fun a => (a.2 : ℚ) * f a.1 b.1).sum).sum := by
+    calc
+      _ = (first.map fun a =>
+          (second.map fun b =>
+            (a.2 : ℚ) * ((b.2 : ℚ) * f a.1 b.1)).sum).sum := by
+        apply congrArg List.sum
+        apply List.map_congr_left
+        intro atom _
+        exact scalar_mul_list_sum (atom.2 : ℚ) second _
+      _ = (second.map fun b =>
+          (first.map fun a =>
+            (a.2 : ℚ) * ((b.2 : ℚ) * f a.1 b.1)).sum).sum :=
+        list_double_sum_comm first second _
+      _ = _ := by
+        apply congrArg List.sum
+        apply List.map_congr_left
+        intro atom _
+        calc
+          (first.map fun a =>
+              (a.2 : ℚ) * ((atom.2 : ℚ) * f a.1 atom.1)).sum =
+              (first.map fun a =>
+                (atom.2 : ℚ) * ((a.2 : ℚ) * f a.1 atom.1)).sum := by
+            apply congrArg List.sum
+            apply List.map_congr_left
+            intro other _
+            ring
+          _ = (atom.2 : ℚ) *
+              (first.map fun a => (a.2 : ℚ) * f a.1 atom.1).sum :=
+            (scalar_mul_list_sum (atom.2 : ℚ) first _).symm
+  exact weighted_double_sum_comm left.atoms right.atoms
+    (fun a b =>
+      (List.map
+        (fun atom => (atom.2 : ℚ) * value atom.1)
+        (next a b).atoms).sum)
+
+end Equivalence
+
+/-! ## Normalization of nonzero weights -/
+
+section Normalization
+
+variable {α β γ : Type*}
+
+/-- Dividing all weights by a fixed scalar divides the total weight by that
+scalar. -/
+private lemma totalWeight_map_div
+    (atoms : List (α × ℚ≥0)) (divisor : ℚ≥0) :
+    totalWeight
+        (atoms.map fun atom =>
+          (atom.1, atom.2 / divisor)) =
+      totalWeight atoms / divisor := by
+  simp only [totalWeight, List.map_map]
+  induction atoms with
+  | nil => simp
+  | cons atom atoms ih =>
+      simp [ih, add_div]
+
+/-- Dividing all weights by their nonzero total produces a normalized law. -/
+private lemma totalWeight_div
+    (atoms : List (α × ℚ≥0)) (hnonzero : totalWeight atoms ≠ 0) :
+    totalWeight
+        (atoms.map fun atom =>
+          (atom.1, atom.2 / totalWeight atoms)) = 1 := by
+  rw [totalWeight_map_div, div_self hnonzero]
+
+/-- Normalize an explicitly nonzero finite weighted list. -/
+def normalize (atoms : List (α × ℚ≥0))
+    (hnonzero : totalWeight atoms ≠ 0) : FiniteLaw α where
+  atoms := atoms.map fun atom =>
+    (atom.1, atom.2 / totalWeight atoms)
+  normalized := by
+    change
+      totalWeight
+        (atoms.map fun atom =>
+          (atom.1, atom.2 / totalWeight atoms)) = 1
+    exact totalWeight_div atoms hnonzero
+
+/-- Point mass after normalization is the raw point weight divided by the
+raw total weight. -/
+theorem mass_normalize [DecidableEq α]
+    (atoms : List (α × ℚ≥0)) (hnonzero : totalWeight atoms ≠ 0)
+    (outcome : α) :
+    (normalize atoms hnonzero).mass outcome =
+      (atoms.map fun atom =>
+        if atom.1 = outcome then atom.2 else 0).sum /
+        totalWeight atoms := by
+  unfold normalize mass eventMass
+  simp only [List.map_map, Function.comp_def]
+  have sum_indicator_div
+      (raw : List (α × ℚ≥0)) (divisor : ℚ≥0) :
+      (raw.map fun atom =>
+        if decide (atom.1 = outcome) then atom.2 / divisor else 0).sum =
+        (raw.map fun atom =>
+          if atom.1 = outcome then atom.2 else 0).sum / divisor := by
+    induction raw with
+    | nil => simp
+    | cons atom raw ih =>
+        rcases atom with ⟨candidate, weight⟩
+        simp only [List.map_cons, List.sum_cons]
+        rw [ih]
+        by_cases heq : candidate = outcome
+        · simp [heq, add_div]
+        · simp [heq]
+  exact sum_indicator_div atoms (totalWeight atoms)
+
+/-- Normalize a nonzero finite weighted list.
+
+An all-zero or empty list returns `none`.  This is the computational boundary
+used by conditioning: no law is invented for a zero-mass event. -/
+def normalize? (atoms : List (α × ℚ≥0)) : Option (FiniteLaw α) :=
+  if hzero : totalWeight atoms = 0 then
+    none
+  else
+    some (normalize atoms hzero)
+
+@[simp]
+lemma normalize?_eq_none_iff (atoms : List (α × ℚ≥0)) :
+    normalize? atoms = none ↔ totalWeight atoms = 0 := by
+  simp [normalize?]
+
+end Normalization
+
+end FiniteLaw

--- a/EconCSLib/Math/Probability/FiniteLaw/Coupling.lean
+++ b/EconCSLib/Math/Probability/FiniteLaw/Coupling.lean
@@ -38,7 +38,7 @@ variable {α : Type uα} {β : Type uβ}
 
 The joint law ranges over the subtype of related pairs, so every sampled
 joint outcome carries its relation witness constructively. -/
-structure RelCoupling {α : Type uα} {β : Type uβ}
+structure RelCoupling
     (R : α → β → Prop) (left : FiniteLaw α) (right : FiniteLaw β) where
   /-- Executable finite joint law of related pairs. -/
   joint : FiniteLaw {pair : α × β // R pair.1 pair.2}
@@ -82,10 +82,13 @@ def relCoupling_refl (law : FiniteLaw α) :
 
 namespace RelCoupling
 
+variable {R : α → β → Prop} {left : FiniteLaw α} {right : FiniteLaw β}
+variable (coupling : RelCoupling R left right)
+
+include coupling
+
 /-- Transpose a relational coupling. -/
-def symm {α : Type uα} {β : Type uβ}
-    {R : α → β → Prop} {left : FiniteLaw α} {right : FiniteLaw β}
-    (coupling : RelCoupling R left right) :
+def symm :
     RelCoupling (fun rightValue leftValue => R leftValue rightValue)
       right left := by
   let swap : {pair : α × β // R pair.1 pair.2} →
@@ -120,9 +123,6 @@ def symm {α : Type uα} {β : Type uβ}
 /-- Every positive atom of the right marginal has a related positive witness
 in the left marginal. -/
 lemma exists_left_of_hasPositiveAtom_right
-    {α : Type uα} {β : Type uβ}
-    {R : α → β → Prop} {left : FiniteLaw α} {right : FiniteLaw β}
-    (coupling : RelCoupling R left right)
     {rightValue : β} (hright : right.HasPositiveAtom rightValue) :
     ∃ leftValue, left.HasPositiveAtom leftValue ∧
       R leftValue rightValue := by
@@ -140,9 +140,6 @@ lemma exists_left_of_hasPositiveAtom_right
 /-- Every positive atom of the left marginal has a related positive witness
 in the right marginal. -/
 lemma exists_right_of_hasPositiveAtom_left
-    {α : Type uα} {β : Type uβ}
-    {R : α → β → Prop} {left : FiniteLaw α} {right : FiniteLaw β}
-    (coupling : RelCoupling R left right)
     {leftValue : α} (hleft : left.HasPositiveAtom leftValue) :
     ∃ rightValue, right.HasPositiveAtom rightValue ∧
       R leftValue rightValue :=
@@ -158,13 +155,12 @@ namespace RelCoupling
 
 section Mapping
 
-variable {α : Type uα} {β : Type uβ}
+variable {α : Type uα} {β : Type uβ} {γ δ : Type*}
+variable {R : α → β → Prop} {S : γ → δ → Prop}
+variable {left : FiniteLaw α} {right : FiniteLaw β}
 
 /-- Push a relational coupling through related deterministic maps. -/
 def map
-    {α : Type uα} {β : Type uβ} {γ : Type*} {δ : Type*}
-    {R : α → β → Prop} {S : γ → δ → Prop}
-    {left : FiniteLaw α} {right : FiniteLaw β}
     {f : α → γ} {g : β → δ}
     (coupling : RelCoupling R left right)
     (hmap : ∀ leftValue rightValue,
@@ -213,9 +209,6 @@ def map
 
 /-- Related observables have equivalent exact finite laws. -/
 theorem map_eq
-    {α : Type uα} {β : Type uβ} {γ : Type*}
-    {R : α → β → Prop}
-    {left : FiniteLaw α} {right : FiniteLaw β}
     {f : α → γ} {g : β → γ}
     (coupling : RelCoupling R left right)
     (hmap : ∀ leftValue rightValue,
@@ -254,8 +247,10 @@ end RelCoupling
 
 section Composition
 
+variable {α : Type uα} {β : Type uβ}
+
 /-- Couple two point laws whenever their outcomes are related. -/
-def relCoupling_pure {α : Type uα} {β : Type uβ}
+def relCoupling_pure
     {R : α → β → Prop} {left : α} {right : β}
     (hrelated : R left right) :
     RelCoupling R (pure left) (pure right) := by
@@ -277,12 +272,66 @@ def relCoupling_pure {α : Type uα} {β : Type uβ}
 
 namespace RelCoupling
 
+section MarginalComposition
+
+variable {A B C D : Type*}
+variable (joint : FiniteLaw A) (marginal : FiniteLaw B)
+variable (next : A → FiniteLaw C) (marginalNext : B → FiniteLaw D)
+variable (project : A → B) (projectNext : C → D)
+
+section Expectations
+
+variable (houter : (joint.map project).Equivalent marginal)
+variable (hinner : ∀ source,
+  ((next source).map projectNext).Equivalent (marginalNext (project source)))
+
+include houter hinner
+
+-- Projection commutes with composition when both marginal laws agree.
+private lemma bind_marginal_equivalent :
+    ((joint.bind next).map projectNext).Equivalent (marginal.bind marginalNext) := by
+  rw [map_bind]
+  apply ((Equivalent.refl joint).bind hinner).trans
+  simpa only [bind_map, Function.comp_def] using
+    houter.bind (fun _ => Equivalent.refl _)
+
+end Expectations
+
+section PositiveAtoms
+
+variable (houter : ∀ outcome,
+  (joint.map project).HasPositiveAtom outcome ↔ marginal.HasPositiveAtom outcome)
+variable (hinner : ∀ source outcome,
+  ((next source).map projectNext).HasPositiveAtom outcome ↔
+    (marginalNext (project source)).HasPositiveAtom outcome)
+
+include houter hinner
+
+-- The same projection argument transports positive-atom witnesses.
+private lemma bind_marginal_positive (outcome : D) :
+    ((joint.bind next).map projectNext).HasPositiveAtom outcome ↔
+      (marginal.bind marginalNext).HasPositiveAtom outcome := by
+  rw [map_bind, hasPositiveAtom_bind_iff, hasPositiveAtom_bind_iff]
+  simp_rw [hinner]
+  constructor
+  · rintro ⟨source, hsource, hnext⟩
+    exact ⟨project source,
+      (houter _).mp ((hasPositiveAtom_map_iff _ _ _).mpr ⟨source, hsource, rfl⟩), hnext⟩
+  · rintro ⟨projected, hprojected, hnext⟩
+    obtain ⟨source, hsource, rfl⟩ :=
+      (hasPositiveAtom_map_iff _ _ _).mp ((houter _).mpr hprojected)
+    exact ⟨source, hsource, hnext⟩
+
+end PositiveAtoms
+
+end MarginalComposition
+
+variable {γ δ : Type*} {R : α → β → Prop} {S : γ → δ → Prop}
+variable {left : FiniteLaw α} {right : FiniteLaw β}
+variable {leftNext : α → FiniteLaw γ} {rightNext : β → FiniteLaw δ}
+
 /-- Compose a coupling with constructively supplied related continuations. -/
 def bind
-    {α : Type uα} {β : Type uβ} {γ : Type*} {δ : Type*}
-    {R : α → β → Prop} {S : γ → δ → Prop}
-    {left : FiniteLaw α} {right : FiniteLaw β}
-    {leftNext : α → FiniteLaw γ} {rightNext : β → FiniteLaw δ}
     (coupling : RelCoupling R left right)
     (nextCoupling : ∀ leftValue rightValue,
       R leftValue rightValue →
@@ -291,138 +340,24 @@ def bind
   let nextForPair := fun pair : {pair : α × β // R pair.1 pair.2} =>
     nextCoupling pair.1.1 pair.1.2 pair.2
   let joint := coupling.joint.bind fun pair => (nextForPair pair).joint
-  refine
+  exact
     { joint := joint
-      leftEquivalent := ?_
-      rightEquivalent := ?_
-      leftPositive := ?_
-      rightPositive := ?_ }
-  · intro value
-    change
-      (joint.map fun pair => pair.1.1).expectRat value =
-        (left.bind leftNext).expectRat value
-    rw [expectRat_map]
-    simp only [joint]
-    rw [expectRat_bind, expectRat_bind]
-    calc
-      coupling.joint.expectRat
-          (fun pair =>
-            ((nextForPair pair).joint).expectRat
-              (value ∘ fun related => related.1.1)) =
-          coupling.joint.expectRat
-            (fun pair => (leftNext pair.1.1).expectRat value) := by
-        congr 1
-        funext pair
-        have hinner :=
-          (equivalent_iff_expectRat.mp
-            (nextForPair pair).leftEquivalent) value
-        rw [expectRat_map] at hinner
-        exact hinner
-      _ = (coupling.joint.map fun pair => pair.1.1).expectRat
-          (fun outcome => (leftNext outcome).expectRat value) := by
-        rw [expectRat_map]
-        rfl
-      _ = left.expectRat
-          (fun outcome => (leftNext outcome).expectRat value) :=
-        (equivalent_iff_expectRat.mp coupling.leftEquivalent) _
-  · intro value
-    change
-      (joint.map fun pair => pair.1.2).expectRat value =
-        (right.bind rightNext).expectRat value
-    rw [expectRat_map]
-    simp only [joint]
-    rw [expectRat_bind, expectRat_bind]
-    calc
-      coupling.joint.expectRat
-          (fun pair =>
-            ((nextForPair pair).joint).expectRat
-              (value ∘ fun related => related.1.2)) =
-          coupling.joint.expectRat
-            (fun pair => (rightNext pair.1.2).expectRat value) := by
-        congr 1
-        funext pair
-        have hinner :=
-          (equivalent_iff_expectRat.mp
-            (nextForPair pair).rightEquivalent) value
-        rw [expectRat_map] at hinner
-        exact hinner
-      _ = (coupling.joint.map fun pair => pair.1.2).expectRat
-          (fun outcome => (rightNext outcome).expectRat value) := by
-        rw [expectRat_map]
-        rfl
-      _ = right.expectRat
-          (fun outcome => (rightNext outcome).expectRat value) :=
-        (equivalent_iff_expectRat.mp coupling.rightEquivalent) _
-  · intro outcome
-    simp only [joint]
-    rw [hasPositiveAtom_bind_iff]
-    rw [hasPositiveAtom_map_iff]
-    simp_rw [hasPositiveAtom_bind_iff]
-    constructor
-    · rintro ⟨relatedOutcome, ⟨pair, hpair, hnext⟩, houtcome⟩
-      have hsourceProjected :
-          (coupling.joint.map fun pair => pair.1.1).HasPositiveAtom
-            pair.1.1 :=
-        (hasPositiveAtom_map_iff _ _ _).mpr ⟨pair, hpair, rfl⟩
-      have hnextProjected :
-          ((nextForPair pair).joint.map fun related =>
-            related.1.1).HasPositiveAtom relatedOutcome.1.1 :=
-        (hasPositiveAtom_map_iff _ _ _).mpr
-          ⟨relatedOutcome, hnext, rfl⟩
-      refine
-        ⟨pair.1.1,
-          (coupling.leftPositive pair.1.1).mp hsourceProjected, ?_⟩
-      have hpositive :=
-        ((nextForPair pair).leftPositive relatedOutcome.1.1).mp
-          hnextProjected
-      simpa [houtcome] using hpositive
-    · rintro ⟨source, hsource, hnext⟩
-      have hsourceProjected :=
-        (coupling.leftPositive source).mpr hsource
-      rw [hasPositiveAtom_map_iff] at hsourceProjected
-      obtain ⟨pair, hpair, hpairSource⟩ := hsourceProjected
-      subst source
-      have hnextProjected :=
-        ((nextForPair pair).leftPositive outcome).mpr hnext
-      rw [hasPositiveAtom_map_iff] at hnextProjected
-      obtain ⟨relatedOutcome, hrelatedOutcome, houtcome⟩ :=
-        hnextProjected
-      exact ⟨relatedOutcome, ⟨pair, hpair, hrelatedOutcome⟩, houtcome⟩
-  · intro outcome
-    simp only [joint]
-    rw [hasPositiveAtom_bind_iff]
-    rw [hasPositiveAtom_map_iff]
-    simp_rw [hasPositiveAtom_bind_iff]
-    constructor
-    · rintro ⟨relatedOutcome, ⟨pair, hpair, hnext⟩, houtcome⟩
-      have htargetProjected :
-          (coupling.joint.map fun pair => pair.1.2).HasPositiveAtom
-            pair.1.2 :=
-        (hasPositiveAtom_map_iff _ _ _).mpr ⟨pair, hpair, rfl⟩
-      have hnextProjected :
-          ((nextForPair pair).joint.map fun related =>
-            related.1.2).HasPositiveAtom relatedOutcome.1.2 :=
-        (hasPositiveAtom_map_iff _ _ _).mpr
-          ⟨relatedOutcome, hnext, rfl⟩
-      refine
-        ⟨pair.1.2,
-          (coupling.rightPositive pair.1.2).mp htargetProjected, ?_⟩
-      have hpositive :=
-        ((nextForPair pair).rightPositive relatedOutcome.1.2).mp
-          hnextProjected
-      simpa [houtcome] using hpositive
-    · rintro ⟨target, htarget, hnext⟩
-      have htargetProjected :=
-        (coupling.rightPositive target).mpr htarget
-      rw [hasPositiveAtom_map_iff] at htargetProjected
-      obtain ⟨pair, hpair, hpairTarget⟩ := htargetProjected
-      subst target
-      have hnextProjected :=
-        ((nextForPair pair).rightPositive outcome).mpr hnext
-      rw [hasPositiveAtom_map_iff] at hnextProjected
-      obtain ⟨relatedOutcome, hrelatedOutcome, houtcome⟩ :=
-        hnextProjected
-      exact ⟨relatedOutcome, ⟨pair, hpair, hrelatedOutcome⟩, houtcome⟩
+      leftEquivalent := bind_marginal_equivalent coupling.joint left
+        (fun pair => (nextForPair pair).joint) leftNext
+        (fun pair => pair.1.1) (fun pair => pair.1.1)
+        coupling.leftEquivalent (fun pair => (nextForPair pair).leftEquivalent)
+      rightEquivalent := bind_marginal_equivalent coupling.joint right
+        (fun pair => (nextForPair pair).joint) rightNext
+        (fun pair => pair.1.2) (fun pair => pair.1.2)
+        coupling.rightEquivalent (fun pair => (nextForPair pair).rightEquivalent)
+      leftPositive := bind_marginal_positive coupling.joint left
+        (fun pair => (nextForPair pair).joint) leftNext
+        (fun pair => pair.1.1) (fun pair => pair.1.1)
+        coupling.leftPositive (fun pair => (nextForPair pair).leftPositive)
+      rightPositive := bind_marginal_positive coupling.joint right
+        (fun pair => (nextForPair pair).joint) rightNext
+        (fun pair => pair.1.2) (fun pair => pair.1.2)
+        coupling.rightPositive (fun pair => (nextForPair pair).rightPositive) }
 
 end RelCoupling
 

--- a/EconCSLib/Math/Probability/FiniteLaw/Coupling.lean
+++ b/EconCSLib/Math/Probability/FiniteLaw/Coupling.lean
@@ -1,0 +1,431 @@
+/-
+Copyright (c) 2026 EconCSLib contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+
+import EconCSLib.Math.Probability.FiniteLaw.Product
+
+/-!
+# Constructive couplings of finite laws
+
+A relational coupling is represented by a finite law on the subtype of
+related pairs.  The relation proof therefore travels with every joint atom;
+dependent coupling composition never extracts data from an existential proof
+and never needs classical choice.
+
+Marginals are compared by exact rational expectations.  Positive-atom
+projection equivalences are retained explicitly because support transfer is
+part of the executable finite semantics.
+
+## Main definitions
+
+* `FiniteLaw.RelCoupling`;
+* `FiniteLaw.relCoupling_refl` and `FiniteLaw.relCoupling_pure`;
+* `FiniteLaw.RelCoupling.map` and `FiniteLaw.RelCoupling.bind`.
+-/
+
+namespace FiniteLaw
+
+universe uα uβ
+
+/-! ## Coupling data and elementary constructions -/
+
+section Basic
+
+variable {α : Type uα} {β : Type uβ}
+
+/-- An explicit finite coupling supported on `R`.
+
+The joint law ranges over the subtype of related pairs, so every sampled
+joint outcome carries its relation witness constructively. -/
+structure RelCoupling {α : Type uα} {β : Type uβ}
+    (R : α → β → Prop) (left : FiniteLaw α) (right : FiniteLaw β) where
+  /-- Executable finite joint law of related pairs. -/
+  joint : FiniteLaw {pair : α × β // R pair.1 pair.2}
+  /-- Exact first marginal, expressed by rational observables. -/
+  leftEquivalent :
+    (joint.map fun pair => pair.1.1).Equivalent left
+  /-- Exact second marginal, expressed by rational observables. -/
+  rightEquivalent :
+    (joint.map fun pair => pair.1.2).Equivalent right
+  /-- Positive atoms of the first marginal are represented exactly. -/
+  leftPositive :
+    ∀ outcome,
+      (joint.map fun pair => pair.1.1).HasPositiveAtom outcome ↔
+        left.HasPositiveAtom outcome
+  /-- Positive atoms of the second marginal are represented exactly. -/
+  rightPositive :
+    ∀ outcome,
+      (joint.map fun pair => pair.1.2).HasPositiveAtom outcome ↔
+        right.HasPositiveAtom outcome
+
+/-- A finite law couples to itself along equality. -/
+def relCoupling_refl (law : FiniteLaw α) :
+    RelCoupling (fun left right : α => left = right) law law := by
+  let diagonal : α → {pair : α × α // pair.1 = pair.2} :=
+    fun outcome => ⟨(outcome, outcome), rfl⟩
+  let joint := law.map diagonal
+  have hleft : (joint.map fun pair => pair.1.1) = law := by
+    simp only [joint]
+    rw [map_comp]
+    simpa [diagonal, Function.comp_def] using map_id law
+  have hright : (joint.map fun pair => pair.1.2) = law := by
+    simp only [joint]
+    rw [map_comp]
+    simpa [diagonal, Function.comp_def] using map_id law
+  exact
+    { joint := joint
+      leftEquivalent := Equivalent.of_eq hleft
+      rightEquivalent := Equivalent.of_eq hright
+      leftPositive := fun outcome => by rw [hleft]
+      rightPositive := fun outcome => by rw [hright] }
+
+namespace RelCoupling
+
+/-- Transpose a relational coupling. -/
+def symm {α : Type uα} {β : Type uβ}
+    {R : α → β → Prop} {left : FiniteLaw α} {right : FiniteLaw β}
+    (coupling : RelCoupling R left right) :
+    RelCoupling (fun rightValue leftValue => R leftValue rightValue)
+      right left := by
+  let swap : {pair : α × β // R pair.1 pair.2} →
+      {pair : β × α // R pair.2 pair.1} :=
+    fun pair => ⟨(pair.1.2, pair.1.1), pair.2⟩
+  let joint := coupling.joint.map swap
+  have hleft :
+      (joint.map fun pair => pair.1.1) =
+        coupling.joint.map (fun pair => pair.1.2) := by
+    simp only [joint]
+    rw [map_comp]
+    rfl
+  have hright :
+      (joint.map fun pair => pair.1.2) =
+        coupling.joint.map (fun pair => pair.1.1) := by
+    simp only [joint]
+    rw [map_comp]
+    rfl
+  exact
+    { joint := joint
+      leftEquivalent :=
+        (Equivalent.of_eq hleft).trans coupling.rightEquivalent
+      rightEquivalent :=
+        (Equivalent.of_eq hright).trans coupling.leftEquivalent
+      leftPositive := fun outcome => by
+        rw [hleft]
+        exact coupling.rightPositive outcome
+      rightPositive := fun outcome => by
+        rw [hright]
+        exact coupling.leftPositive outcome }
+
+/-- Every positive atom of the right marginal has a related positive witness
+in the left marginal. -/
+lemma exists_left_of_hasPositiveAtom_right
+    {α : Type uα} {β : Type uβ}
+    {R : α → β → Prop} {left : FiniteLaw α} {right : FiniteLaw β}
+    (coupling : RelCoupling R left right)
+    {rightValue : β} (hright : right.HasPositiveAtom rightValue) :
+    ∃ leftValue, left.HasPositiveAtom leftValue ∧
+      R leftValue rightValue := by
+  have hprojected := (coupling.rightPositive rightValue).mpr hright
+  rw [hasPositiveAtom_map_iff] at hprojected
+  obtain ⟨pair, hpair, hrightPair⟩ := hprojected
+  have hleftProjected :
+      (coupling.joint.map fun pair => pair.1.1).HasPositiveAtom
+        pair.1.1 :=
+    (hasPositiveAtom_map_iff _ _ _).mpr ⟨pair, hpair, rfl⟩
+  exact
+    ⟨pair.1.1, (coupling.leftPositive pair.1.1).mp hleftProjected,
+      hrightPair ▸ pair.2⟩
+
+/-- Every positive atom of the left marginal has a related positive witness
+in the right marginal. -/
+lemma exists_right_of_hasPositiveAtom_left
+    {α : Type uα} {β : Type uβ}
+    {R : α → β → Prop} {left : FiniteLaw α} {right : FiniteLaw β}
+    (coupling : RelCoupling R left right)
+    {leftValue : α} (hleft : left.HasPositiveAtom leftValue) :
+    ∃ rightValue, right.HasPositiveAtom rightValue ∧
+      R leftValue rightValue :=
+  coupling.symm.exists_left_of_hasPositiveAtom_right hleft
+
+end RelCoupling
+
+end Basic
+
+/-! ## Transporting a coupling and its observables -/
+
+namespace RelCoupling
+
+section Mapping
+
+variable {α : Type uα} {β : Type uβ}
+
+/-- Push a relational coupling through related deterministic maps. -/
+def map
+    {α : Type uα} {β : Type uβ} {γ : Type*} {δ : Type*}
+    {R : α → β → Prop} {S : γ → δ → Prop}
+    {left : FiniteLaw α} {right : FiniteLaw β}
+    {f : α → γ} {g : β → δ}
+    (coupling : RelCoupling R left right)
+    (hmap : ∀ leftValue rightValue,
+      R leftValue rightValue → S (f leftValue) (g rightValue)) :
+    RelCoupling S (left.map f) (right.map g) := by
+  let push : {pair : α × β // R pair.1 pair.2} →
+      {pair : γ × δ // S pair.1 pair.2} :=
+    fun pair =>
+      ⟨(f pair.1.1, g pair.1.2),
+        hmap pair.1.1 pair.1.2 pair.2⟩
+  let joint := coupling.joint.map push
+  have hleft :
+      (joint.map fun pair => pair.1.1) =
+        (coupling.joint.map fun pair => pair.1.1).map f := by
+    simp only [joint]
+    rw [map_comp, map_comp]
+    rfl
+  have hright :
+      (joint.map fun pair => pair.1.2) =
+        (coupling.joint.map fun pair => pair.1.2).map g := by
+    simp only [joint]
+    rw [map_comp, map_comp]
+    rfl
+  refine
+    { joint := joint
+      leftEquivalent :=
+        (Equivalent.of_eq hleft).trans (coupling.leftEquivalent.map f)
+      rightEquivalent :=
+        (Equivalent.of_eq hright).trans (coupling.rightEquivalent.map g)
+      leftPositive := ?_
+      rightPositive := ?_ }
+  · intro outcome
+    rw [hleft, hasPositiveAtom_map_iff, hasPositiveAtom_map_iff]
+    constructor
+    · rintro ⟨source, hsource, rfl⟩
+      exact ⟨source, (coupling.leftPositive source).mp hsource, rfl⟩
+    · rintro ⟨source, hsource, rfl⟩
+      exact ⟨source, (coupling.leftPositive source).mpr hsource, rfl⟩
+  · intro outcome
+    rw [hright, hasPositiveAtom_map_iff, hasPositiveAtom_map_iff]
+    constructor
+    · rintro ⟨source, hsource, rfl⟩
+      exact ⟨source, (coupling.rightPositive source).mp hsource, rfl⟩
+    · rintro ⟨source, hsource, rfl⟩
+      exact ⟨source, (coupling.rightPositive source).mpr hsource, rfl⟩
+
+/-- Related observables have equivalent exact finite laws. -/
+theorem map_eq
+    {α : Type uα} {β : Type uβ} {γ : Type*}
+    {R : α → β → Prop}
+    {left : FiniteLaw α} {right : FiniteLaw β}
+    {f : α → γ} {g : β → γ}
+    (coupling : RelCoupling R left right)
+    (hmap : ∀ leftValue rightValue,
+      R leftValue rightValue → f leftValue = g rightValue) :
+    (left.map f).Equivalent (right.map g) := by
+  intro value
+  change
+    (left.map f).expectRat value = (right.map g).expectRat value
+  rw [expectRat_map, expectRat_map]
+  calc
+    left.expectRat (value ∘ f) =
+        (coupling.joint.map fun pair => pair.1.1).expectRat
+          (value ∘ f) :=
+      ((equivalent_iff_expectRat.mp coupling.leftEquivalent)
+        (value ∘ f)).symm
+    _ = coupling.joint.expectRat
+        ((value ∘ f) ∘ fun pair => pair.1.1) := by
+      rw [expectRat_map]
+    _ = coupling.joint.expectRat
+        ((value ∘ g) ∘ fun pair => pair.1.2) := by
+      congr 1
+      funext pair
+      simp only [Function.comp_apply]
+      rw [hmap pair.1.1 pair.1.2 pair.2]
+    _ = (coupling.joint.map fun pair => pair.1.2).expectRat
+        (value ∘ g) := by
+      rw [expectRat_map]
+    _ = right.expectRat (value ∘ g) :=
+      (equivalent_iff_expectRat.mp coupling.rightEquivalent) _
+
+end Mapping
+
+end RelCoupling
+
+/-! ## Point laws and dependent composition -/
+
+section Composition
+
+/-- Couple two point laws whenever their outcomes are related. -/
+def relCoupling_pure {α : Type uα} {β : Type uβ}
+    {R : α → β → Prop} {left : α} {right : β}
+    (hrelated : R left right) :
+    RelCoupling R (pure left) (pure right) := by
+  let pair : {pair : α × β // R pair.1 pair.2} :=
+    ⟨(left, right), hrelated⟩
+  let joint := pure pair
+  have hleft : (joint.map fun pair => pair.1.1) = pure left := by
+    simp only [joint]
+    rw [pure_map]
+  have hright : (joint.map fun pair => pair.1.2) = pure right := by
+    simp only [joint]
+    rw [pure_map]
+  exact
+    { joint := joint
+      leftEquivalent := Equivalent.of_eq hleft
+      rightEquivalent := Equivalent.of_eq hright
+      leftPositive := fun outcome => by rw [hleft]
+      rightPositive := fun outcome => by rw [hright] }
+
+namespace RelCoupling
+
+/-- Compose a coupling with constructively supplied related continuations. -/
+def bind
+    {α : Type uα} {β : Type uβ} {γ : Type*} {δ : Type*}
+    {R : α → β → Prop} {S : γ → δ → Prop}
+    {left : FiniteLaw α} {right : FiniteLaw β}
+    {leftNext : α → FiniteLaw γ} {rightNext : β → FiniteLaw δ}
+    (coupling : RelCoupling R left right)
+    (nextCoupling : ∀ leftValue rightValue,
+      R leftValue rightValue →
+        RelCoupling S (leftNext leftValue) (rightNext rightValue)) :
+    RelCoupling S (left.bind leftNext) (right.bind rightNext) := by
+  let nextForPair := fun pair : {pair : α × β // R pair.1 pair.2} =>
+    nextCoupling pair.1.1 pair.1.2 pair.2
+  let joint := coupling.joint.bind fun pair => (nextForPair pair).joint
+  refine
+    { joint := joint
+      leftEquivalent := ?_
+      rightEquivalent := ?_
+      leftPositive := ?_
+      rightPositive := ?_ }
+  · intro value
+    change
+      (joint.map fun pair => pair.1.1).expectRat value =
+        (left.bind leftNext).expectRat value
+    rw [expectRat_map]
+    simp only [joint]
+    rw [expectRat_bind, expectRat_bind]
+    calc
+      coupling.joint.expectRat
+          (fun pair =>
+            ((nextForPair pair).joint).expectRat
+              (value ∘ fun related => related.1.1)) =
+          coupling.joint.expectRat
+            (fun pair => (leftNext pair.1.1).expectRat value) := by
+        congr 1
+        funext pair
+        have hinner :=
+          (equivalent_iff_expectRat.mp
+            (nextForPair pair).leftEquivalent) value
+        rw [expectRat_map] at hinner
+        exact hinner
+      _ = (coupling.joint.map fun pair => pair.1.1).expectRat
+          (fun outcome => (leftNext outcome).expectRat value) := by
+        rw [expectRat_map]
+        rfl
+      _ = left.expectRat
+          (fun outcome => (leftNext outcome).expectRat value) :=
+        (equivalent_iff_expectRat.mp coupling.leftEquivalent) _
+  · intro value
+    change
+      (joint.map fun pair => pair.1.2).expectRat value =
+        (right.bind rightNext).expectRat value
+    rw [expectRat_map]
+    simp only [joint]
+    rw [expectRat_bind, expectRat_bind]
+    calc
+      coupling.joint.expectRat
+          (fun pair =>
+            ((nextForPair pair).joint).expectRat
+              (value ∘ fun related => related.1.2)) =
+          coupling.joint.expectRat
+            (fun pair => (rightNext pair.1.2).expectRat value) := by
+        congr 1
+        funext pair
+        have hinner :=
+          (equivalent_iff_expectRat.mp
+            (nextForPair pair).rightEquivalent) value
+        rw [expectRat_map] at hinner
+        exact hinner
+      _ = (coupling.joint.map fun pair => pair.1.2).expectRat
+          (fun outcome => (rightNext outcome).expectRat value) := by
+        rw [expectRat_map]
+        rfl
+      _ = right.expectRat
+          (fun outcome => (rightNext outcome).expectRat value) :=
+        (equivalent_iff_expectRat.mp coupling.rightEquivalent) _
+  · intro outcome
+    simp only [joint]
+    rw [hasPositiveAtom_bind_iff]
+    rw [hasPositiveAtom_map_iff]
+    simp_rw [hasPositiveAtom_bind_iff]
+    constructor
+    · rintro ⟨relatedOutcome, ⟨pair, hpair, hnext⟩, houtcome⟩
+      have hsourceProjected :
+          (coupling.joint.map fun pair => pair.1.1).HasPositiveAtom
+            pair.1.1 :=
+        (hasPositiveAtom_map_iff _ _ _).mpr ⟨pair, hpair, rfl⟩
+      have hnextProjected :
+          ((nextForPair pair).joint.map fun related =>
+            related.1.1).HasPositiveAtom relatedOutcome.1.1 :=
+        (hasPositiveAtom_map_iff _ _ _).mpr
+          ⟨relatedOutcome, hnext, rfl⟩
+      refine
+        ⟨pair.1.1,
+          (coupling.leftPositive pair.1.1).mp hsourceProjected, ?_⟩
+      have hpositive :=
+        ((nextForPair pair).leftPositive relatedOutcome.1.1).mp
+          hnextProjected
+      simpa [houtcome] using hpositive
+    · rintro ⟨source, hsource, hnext⟩
+      have hsourceProjected :=
+        (coupling.leftPositive source).mpr hsource
+      rw [hasPositiveAtom_map_iff] at hsourceProjected
+      obtain ⟨pair, hpair, hpairSource⟩ := hsourceProjected
+      subst source
+      have hnextProjected :=
+        ((nextForPair pair).leftPositive outcome).mpr hnext
+      rw [hasPositiveAtom_map_iff] at hnextProjected
+      obtain ⟨relatedOutcome, hrelatedOutcome, houtcome⟩ :=
+        hnextProjected
+      exact ⟨relatedOutcome, ⟨pair, hpair, hrelatedOutcome⟩, houtcome⟩
+  · intro outcome
+    simp only [joint]
+    rw [hasPositiveAtom_bind_iff]
+    rw [hasPositiveAtom_map_iff]
+    simp_rw [hasPositiveAtom_bind_iff]
+    constructor
+    · rintro ⟨relatedOutcome, ⟨pair, hpair, hnext⟩, houtcome⟩
+      have htargetProjected :
+          (coupling.joint.map fun pair => pair.1.2).HasPositiveAtom
+            pair.1.2 :=
+        (hasPositiveAtom_map_iff _ _ _).mpr ⟨pair, hpair, rfl⟩
+      have hnextProjected :
+          ((nextForPair pair).joint.map fun related =>
+            related.1.2).HasPositiveAtom relatedOutcome.1.2 :=
+        (hasPositiveAtom_map_iff _ _ _).mpr
+          ⟨relatedOutcome, hnext, rfl⟩
+      refine
+        ⟨pair.1.2,
+          (coupling.rightPositive pair.1.2).mp htargetProjected, ?_⟩
+      have hpositive :=
+        ((nextForPair pair).rightPositive relatedOutcome.1.2).mp
+          hnextProjected
+      simpa [houtcome] using hpositive
+    · rintro ⟨target, htarget, hnext⟩
+      have htargetProjected :=
+        (coupling.rightPositive target).mpr htarget
+      rw [hasPositiveAtom_map_iff] at htargetProjected
+      obtain ⟨pair, hpair, hpairTarget⟩ := htargetProjected
+      subst target
+      have hnextProjected :=
+        ((nextForPair pair).rightPositive outcome).mpr hnext
+      rw [hasPositiveAtom_map_iff] at hnextProjected
+      obtain ⟨relatedOutcome, hrelatedOutcome, houtcome⟩ :=
+        hnextProjected
+      exact ⟨relatedOutcome, ⟨pair, hpair, hrelatedOutcome⟩, houtcome⟩
+
+end RelCoupling
+
+end Composition
+
+end FiniteLaw

--- a/EconCSLib/Math/Probability/FiniteLaw/DeferredSampling.lean
+++ b/EconCSLib/Math/Probability/FiniteLaw/DeferredSampling.lean
@@ -276,106 +276,68 @@ end Execution
 
 section DeferredDecisions
 
+variable (laws : (i : ι) → FiniteLaw (X i))
+
+private lemma runPresampled_done {remaining : Finset ι} (result : R) :
+    (runPresampled laws (.done (remaining := remaining) result)).Equivalent (pure result) := by
+  intro value
+  change
+    ((fintypePi fun i : ↥remaining => laws i.1).bind fun _ => pure result).expectRat value =
+      (pure result).expectRat value
+  rw [expectRat_bind, expectRat_pure, expectRat_const]
+
+-- Independent chance can be drawn before the pre-sampled table.
+private lemma runPresampled_chance {remaining : Finset ι} {C : Type uX}
+    (law : FiniteLaw C) (next : C → FreshQueryTree X R remaining) :
+    (runPresampled laws (.chance law next)).Equivalent
+      (law.bind fun outcome => runPresampled laws (next outcome)) :=
+  bind_comm_equivalent (fintypePi fun i : ↥remaining => laws i.1) law
+    (fun table outcome => runWithTable (next outcome) table)
+
+-- A fresh query splits the independent table into its answer and the unused coordinates.
+private lemma runPresampled_query {remaining : Finset ι}
+    (selected : ↥remaining)
+    (next : X selected.1 → FreshQueryTree X R (remaining.erase selected.1)) :
+    (runPresampled laws (.query selected next)).Equivalent
+      ((laws selected.1).bind fun value => runPresampled laws (next value)) := by
+  let split := finsetPiSplitAt (X := X) remaining selected
+  let remainingLaw := fintypePi fun i : ↥(remaining.erase selected.1) => laws i.1
+  apply Equivalent.trans
+    (second := ((fintypePi fun i : ↥remaining => laws i.1).map split).bind
+      (fun pair => runWithTable (.query selected next) (split.symm pair)))
+  · apply Equivalent.of_eq
+    simp only [bind_map, runPresampled, Function.comp_def, Equiv.symm_apply_apply]
+  · apply Equivalent.trans
+      (second := (independentPair (laws selected.1) remainingLaw).bind
+        (fun pair => runWithTable (.query selected next) (split.symm pair)))
+    · exact (fintypePi_finset_splitAt laws remaining selected).bind
+        (fun _ => Equivalent.refl _)
+    · apply Equivalent.of_eq
+      unfold independentPair
+      simp [bind_bind, bind_map, split, remainingLaw,
+        runWithTable, runPresampled, Function.comp_def]
+
 /-- Pre-sampling all independent query answers and sampling them only when
 first queried induce exactly the same result law.
 
 The result is exact equality of all rational observables, not structural
 equality of sparse atom-list presentations. -/
-theorem runPresampled_eq_runOnDemand
-    (laws : (i : ι) → FiniteLaw (X i)) :
-    ∀ {remaining : Finset ι}
-      (tree : FreshQueryTree X R remaining),
-      (runPresampled laws tree).Equivalent
-        (runOnDemand laws tree) := by
+theorem runPresampled_eq_runOnDemand :
+    ∀ {remaining : Finset ι} (tree : FreshQueryTree X R remaining),
+      (runPresampled laws tree).Equivalent (runOnDemand laws tree) := by
   intro remaining tree
   induction tree with
   | done result =>
-      simp only [runPresampled, runWithTable, runOnDemand]
-      intro value
-      change
-        (_root_.FiniteLaw.bind _ fun _ => pure result).expectRat value =
-          (pure result).expectRat value
-      rw [expectRat_bind, expectRat_pure, expectRat_const]
-  | @chance remaining C law next ih =>
-      change
-        ((fintypePi
-          (fun i : ↥remaining => laws i.1)).bind
-            (fun table =>
-              law.bind fun outcome =>
-                runWithTable (next outcome) table)).Equivalent
-          (law.bind fun outcome =>
-            runOnDemand laws (next outcome))
-      apply Equivalent.trans
-        (second :=
-          law.bind fun outcome =>
-            (fintypePi
-              (fun i : ↥remaining => laws i.1)).bind
-                (fun table => runWithTable (next outcome) table))
-      · exact bind_comm_equivalent
-          (fintypePi fun i : ↥remaining => laws i.1) law
-          (fun table outcome => runWithTable (next outcome) table)
-      · apply (Equivalent.refl law).bind
-        intro outcome
-        exact ih outcome
-  | @query remaining selected next ih =>
-      let split :=
-        finsetPiSplitAt (X := X)
-          remaining selected
-      let remainingLaw :=
-        fintypePi
-          (fun i : ↥(remaining.erase selected.1) =>
-            laws i.1)
-      apply Equivalent.trans
-        (second :=
-          ((fintypePi
-            (fun i : ↥remaining => laws i.1)).map split).bind
-            (fun pair =>
-              runWithTable (.query selected next) (split.symm pair)))
-      · apply Equivalent.of_eq
-        rw [bind_map]
-        unfold runPresampled
-        apply congrArg (fun continuation =>
-          (fintypePi
-            (fun i : ↥remaining => laws i.1)).bind continuation)
-        funext table
-        change
-          runWithTable (.query selected next) table =
-            runWithTable (.query selected next)
-              (split.symm (split table))
-        rw [Equiv.symm_apply_apply]
-      · apply Equivalent.trans
-          (second :=
-            (independentPair
-              (laws selected.1) remainingLaw).bind
-                (fun pair =>
-                  runWithTable (.query selected next) (split.symm pair)))
-        · exact
-            (fintypePi_finset_splitAt laws remaining selected).bind
-              (fun _ => Equivalent.refl _)
-        · apply Equivalent.trans
-            (second :=
-              (laws selected.1).bind fun value =>
-                remainingLaw.bind fun table =>
-                  runWithTable (next value) table)
-          · apply Equivalent.of_eq
-            unfold independentPair
-            rw [bind_bind]
-            apply congrArg (fun continuation =>
-              (laws selected.1).bind continuation)
-            funext value
-            rw [bind_map]
-            apply congrArg (fun continuation =>
-              remainingLaw.bind continuation)
-            funext table
-            simp [split, runWithTable]
-          · change
-              ((laws selected.1).bind fun value =>
-                runPresampled laws (next value)).Equivalent
-                ((laws selected.1).bind fun value =>
-                  runOnDemand laws (next value))
-            apply (Equivalent.refl (laws selected.1)).bind
-            intro value
-            exact ih value
+      simp only [runOnDemand]
+      exact runPresampled_done laws result
+  | chance law next ih =>
+      simp only [runOnDemand]
+      exact (runPresampled_chance laws law next).trans
+        ((Equivalent.refl law).bind ih)
+  | query selected next ih =>
+      simp only [runOnDemand]
+      exact (runPresampled_query laws selected next).trans
+        ((Equivalent.refl (laws selected.1)).bind ih)
 
 end DeferredDecisions
 

--- a/EconCSLib/Math/Probability/FiniteLaw/DeferredSampling.lean
+++ b/EconCSLib/Math/Probability/FiniteLaw/DeferredSampling.lean
@@ -1,0 +1,384 @@
+/-
+Copyright (c) 2026 EconCSLib contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+
+import EconCSLib.Math.Probability.FiniteLaw.Product
+import Mathlib.Data.Fintype.BigOperators
+
+/-!
+# Deferred sampling for fresh adaptive queries
+
+A `FreshQueryTree` may terminate, draw from an arbitrary chance `FiniteLaw`, or
+query one coordinate from a finite family of independent laws.  Querying
+removes that key from the remaining finite set, so freshness is structural:
+no branch can query one coordinate twice.
+
+There are two semantics:
+
+* `runOnDemand` samples a queried coordinate when the query is reached;
+* `runPresampled` independently samples every initially available coordinate
+  first and subsequently looks values up in that table.
+
+`runPresampled_eq_runOnDemand` proves semantic equality of the resulting
+`FiniteLaw`s.
+Chance draws may be interleaved with adaptive coordinate queries.  The proof
+uses the commutativity of FiniteLaw bind at chance nodes and the finite dependent
+product split theorem at query nodes.
+
+This module is representation-neutral: it assumes an explicitly supplied
+fresh-query tree and constructs both result laws. Applications must provide
+their own tree representation and correctness bridge.
+
+## Main definitions
+
+* `FiniteLaw.FreshQueryTree`.
+* `FiniteLaw.FreshQueryTree.runOnDemand`.
+* `FiniteLaw.FreshQueryTree.runPresampled`.
+
+## Main results
+
+* `FiniteLaw.fintypePi_finset_splitAt`.
+* `FiniteLaw.FreshQueryTree.runPresampled_eq_runOnDemand`.
+-/
+
+namespace FiniteLaw
+
+universe uι uX uR
+
+variable {ι : Type uι} [LinearOrder ι]
+variable {X : ι → Type uX} {R : Type uR}
+
+/-! ## Splitting a finite independent table -/
+
+section TableSplitting
+
+/-- Removing the selected element from a finite set is equivalent to taking
+the complement of that element inside the original finite subtype. -/
+def finsetEraseEquiv (remaining : Finset ι)
+    (selected : ↥remaining) :
+    {i : ↥remaining // i ≠ selected} ≃
+      ↥(remaining.erase selected.1) where
+  toFun i :=
+    ⟨i.1.1, Finset.mem_erase.mpr
+      ⟨by
+        intro heq
+        apply i.2
+        exact Subtype.ext heq,
+       i.1.2⟩⟩
+  invFun i :=
+    ⟨⟨i.1, (Finset.mem_erase.mp i.2).2⟩,
+      by
+        intro heq
+        exact
+          (Finset.mem_erase.mp i.2).1
+            (congrArg Subtype.val heq)⟩
+  left_inv i := by
+    apply Subtype.ext
+    apply Subtype.ext
+    rfl
+  right_inv i := by
+    apply Subtype.ext
+    rfl
+
+/-- Split a dependent table on a finite set into the selected coordinate and
+the table on the erased set. -/
+def finsetPiSplitAt (remaining : Finset ι)
+    (selected : ↥remaining) :
+    ((i : ↥remaining) → X i.1) ≃
+      X selected.1 ×
+        ((i : ↥(remaining.erase selected.1)) → X i.1) :=
+  (Equiv.piSplitAt selected (fun i : ↥remaining => X i.1)).trans
+    ((Equiv.refl (X selected.1)).prodCongr
+      ((finsetEraseEquiv remaining selected).piCongr
+        (fun _ => Equiv.refl _)))
+
+/-- A finite dependent product restricted to a `Finset` splits into the
+selected coordinate and the product on the erased set. -/
+theorem fintypePi_finset_splitAt
+    (laws : (i : ι) → FiniteLaw (X i))
+    (remaining : Finset ι)
+    (selected : ↥remaining) :
+    (fintypePi
+        (fun i : ↥remaining => laws i.1)).map
+          (finsetPiSplitAt remaining selected) |>.Equivalent
+      (independentPair
+        (laws selected.1)
+        (fintypePi
+          (fun i : ↥(remaining.erase selected.1) =>
+            laws i.1))) := by
+  classical
+  apply Equivalent.of_mass_eq
+  intro outcome
+  rw [mass_map_equiv, fintypePi_mass,
+    independentPair_mass, fintypePi_mass,
+    Fintype.prod_eq_mul_prod_subtype_ne]
+  have hselected :
+      (laws selected.1).mass
+          ((finsetPiSplitAt remaining selected).symm
+            outcome selected) =
+        (laws selected.1).mass outcome.1 := by
+    congr 2
+    simp [finsetPiSplitAt, finsetEraseEquiv,
+      Equiv.piSplitAt]
+  rw [hselected]
+  apply congrArg (fun mass =>
+    (laws selected.1).mass outcome.1 * mass)
+  exact
+    Fintype.prod_equiv
+      (finsetEraseEquiv remaining selected)
+      (fun i =>
+        (laws i.1.1).mass
+          ((finsetPiSplitAt remaining selected).symm
+            outcome i.1))
+      (fun i => (laws i.1).mass (outcome.2 i))
+      (by
+        intro i
+        simp [finsetPiSplitAt, finsetEraseEquiv,
+          Equiv.piSplitAt, i.2]
+        congr)
+
+end TableSplitting
+
+/-! ## Fresh-query syntax and table operations -/
+
+/-- A finite adaptive computation that may interleave chance draws with
+queries to an independently distributed table.
+
+The `query` constructor erases its key from `remaining`, making freshness a
+typing invariant rather than an external side condition. -/
+inductive FreshQueryTree (X : ι → Type uX) (R : Type uR) :
+    Finset ι → Type (max uι uR (uX + 1)) where
+  /-- Terminate with a result. -/
+  | done {remaining : Finset ι} (result : R) :
+      FreshQueryTree X R remaining
+  /-- Draw an auxiliary chance outcome without consuming a query key. -/
+  | chance {remaining : Finset ι} {C : Type uX}
+      (law : FiniteLaw C)
+      (next : C → FreshQueryTree X R remaining) :
+      FreshQueryTree X R remaining
+  /-- Query one still-available coordinate, then erase it. -/
+  | query {remaining : Finset ι}
+      (selected : ↥remaining)
+      (next :
+        X selected.1 →
+          FreshQueryTree X R
+            (remaining.erase selected.1)) :
+      FreshQueryTree X R remaining
+
+namespace FreshQueryTree
+
+/-- Restrict a table on `remaining` to the set obtained by erasing one
+selected coordinate. -/
+def eraseTable {remaining : Finset ι}
+    (selected : ↥remaining)
+    (table : (i : ↥remaining) → X i.1) :
+    (i : ↥(remaining.erase selected.1)) → X i.1 :=
+  fun i =>
+    table ⟨i.1, (Finset.mem_erase.mp i.2).2⟩
+
+@[simp]
+lemma finsetPiSplitAt_apply
+    {remaining : Finset ι}
+    (selected : ↥remaining)
+    (table : (i : ↥remaining) → X i.1) :
+    finsetPiSplitAt remaining selected table =
+      (table selected, eraseTable selected table) := by
+  apply Prod.ext
+  · simp [finsetPiSplitAt, finsetEraseEquiv,
+      Equiv.piSplitAt]
+  · funext i
+    simp [finsetPiSplitAt, finsetEraseEquiv,
+      Equiv.piSplitAt, eraseTable]
+    congr
+
+@[simp]
+lemma finsetPiSplitAt_symm_selected
+    {remaining : Finset ι}
+    (selected : ↥remaining)
+    (table :
+      X selected.1 ×
+        ((i : ↥(remaining.erase selected.1)) → X i.1)) :
+    (finsetPiSplitAt remaining selected).symm
+        table selected =
+      table.1 := by
+  have h :=
+    (finsetPiSplitAt remaining selected).apply_symm_apply
+      table
+  rw [finsetPiSplitAt_apply] at h
+  exact congrArg Prod.fst h
+
+@[simp]
+lemma eraseTable_finsetPiSplitAt_symm
+    {remaining : Finset ι}
+    (selected : ↥remaining)
+    (table :
+      X selected.1 ×
+        ((i : ↥(remaining.erase selected.1)) → X i.1)) :
+    eraseTable selected
+        ((finsetPiSplitAt remaining selected).symm table) =
+      table.2 := by
+  have h :=
+    (finsetPiSplitAt remaining selected).apply_symm_apply
+      table
+  rw [finsetPiSplitAt_apply] at h
+  exact congrArg Prod.snd h
+
+/-! ## Operational semantics -/
+
+section Execution
+
+/-- Execute chance nodes while answering query nodes from a fixed table. -/
+def runWithTable :
+    {remaining : Finset ι} →
+      FreshQueryTree X R remaining →
+      ((i : ↥remaining) → X i.1) →
+      FiniteLaw R
+  | _, .done result, _ =>
+      FiniteLaw.pure result
+  | _, .chance law next, table =>
+      law.bind fun outcome =>
+        runWithTable (next outcome) table
+  | _, .query selected next, table =>
+      runWithTable
+        (next (table selected))
+        (eraseTable selected table)
+
+/-- Execute a fresh-query tree by drawing each coordinate only when queried. -/
+def runOnDemand
+    (laws : (i : ι) → FiniteLaw (X i)) :
+    {remaining : Finset ι} →
+      FreshQueryTree X R remaining →
+      FiniteLaw R
+  | _, .done result =>
+      FiniteLaw.pure result
+  | _, .chance law next =>
+      law.bind fun outcome =>
+        runOnDemand laws (next outcome)
+  | _, .query selected next =>
+      (laws selected.1).bind fun value =>
+        runOnDemand laws (next value)
+
+/-- Execute a fresh-query tree after independently sampling every initially
+available coordinate. -/
+def runPresampled
+    (laws : (i : ι) → FiniteLaw (X i))
+    {remaining : Finset ι}
+    (tree : FreshQueryTree X R remaining) :
+    FiniteLaw R :=
+  (fintypePi
+    (fun i : ↥remaining => laws i.1)).bind
+      (runWithTable tree)
+
+end Execution
+
+/-! ## Equivalence of pre-sampling and on-demand sampling -/
+
+section DeferredDecisions
+
+/-- Pre-sampling all independent query answers and sampling them only when
+first queried induce exactly the same result law.
+
+The result is exact equality of all rational observables, not structural
+equality of sparse atom-list presentations. -/
+theorem runPresampled_eq_runOnDemand
+    (laws : (i : ι) → FiniteLaw (X i)) :
+    ∀ {remaining : Finset ι}
+      (tree : FreshQueryTree X R remaining),
+      (runPresampled laws tree).Equivalent
+        (runOnDemand laws tree) := by
+  intro remaining tree
+  induction tree with
+  | done result =>
+      simp only [runPresampled, runWithTable, runOnDemand]
+      intro value
+      change
+        (_root_.FiniteLaw.bind _ fun _ => pure result).expectRat value =
+          (pure result).expectRat value
+      rw [expectRat_bind, expectRat_pure, expectRat_const]
+  | @chance remaining C law next ih =>
+      change
+        ((fintypePi
+          (fun i : ↥remaining => laws i.1)).bind
+            (fun table =>
+              law.bind fun outcome =>
+                runWithTable (next outcome) table)).Equivalent
+          (law.bind fun outcome =>
+            runOnDemand laws (next outcome))
+      apply Equivalent.trans
+        (second :=
+          law.bind fun outcome =>
+            (fintypePi
+              (fun i : ↥remaining => laws i.1)).bind
+                (fun table => runWithTable (next outcome) table))
+      · exact bind_comm_equivalent
+          (fintypePi fun i : ↥remaining => laws i.1) law
+          (fun table outcome => runWithTable (next outcome) table)
+      · apply (Equivalent.refl law).bind
+        intro outcome
+        exact ih outcome
+  | @query remaining selected next ih =>
+      let split :=
+        finsetPiSplitAt (X := X)
+          remaining selected
+      let remainingLaw :=
+        fintypePi
+          (fun i : ↥(remaining.erase selected.1) =>
+            laws i.1)
+      apply Equivalent.trans
+        (second :=
+          ((fintypePi
+            (fun i : ↥remaining => laws i.1)).map split).bind
+            (fun pair =>
+              runWithTable (.query selected next) (split.symm pair)))
+      · apply Equivalent.of_eq
+        rw [bind_map]
+        unfold runPresampled
+        apply congrArg (fun continuation =>
+          (fintypePi
+            (fun i : ↥remaining => laws i.1)).bind continuation)
+        funext table
+        change
+          runWithTable (.query selected next) table =
+            runWithTable (.query selected next)
+              (split.symm (split table))
+        rw [Equiv.symm_apply_apply]
+      · apply Equivalent.trans
+          (second :=
+            (independentPair
+              (laws selected.1) remainingLaw).bind
+                (fun pair =>
+                  runWithTable (.query selected next) (split.symm pair)))
+        · exact
+            (fintypePi_finset_splitAt laws remaining selected).bind
+              (fun _ => Equivalent.refl _)
+        · apply Equivalent.trans
+            (second :=
+              (laws selected.1).bind fun value =>
+                remainingLaw.bind fun table =>
+                  runWithTable (next value) table)
+          · apply Equivalent.of_eq
+            unfold independentPair
+            rw [bind_bind]
+            apply congrArg (fun continuation =>
+              (laws selected.1).bind continuation)
+            funext value
+            rw [bind_map]
+            apply congrArg (fun continuation =>
+              remainingLaw.bind continuation)
+            funext table
+            simp [split, runWithTable]
+          · change
+              ((laws selected.1).bind fun value =>
+                runPresampled laws (next value)).Equivalent
+                ((laws selected.1).bind fun value =>
+                  runOnDemand laws (next value))
+            apply (Equivalent.refl (laws selected.1)).bind
+            intro value
+            exact ih value
+
+end DeferredDecisions
+
+end FreshQueryTree
+
+end FiniteLaw

--- a/EconCSLib/Math/Probability/FiniteLaw/Product.lean
+++ b/EconCSLib/Math/Probability/FiniteLaw/Product.lean
@@ -252,24 +252,6 @@ end FinProducts
 
 /-! ## Products indexed by an ordered finite type -/
 
-section FintypeProducts
-
-/-- Independent product over an explicitly enumerable finite index type.
-
-The supplied linear order turns `Fintype.elems` into an executable sorted
-enumeration; no classical `Fintype.equivFin` choice is used. -/
-def fintypePi {I : Type*} [Fintype I] [LinearOrder I]
-    {X : I → Type uα}
-    (laws : (i : I) → FiniteLaw (X i)) :
-    FiniteLaw ((i : I) → X i) :=
-  let indices : List I := Finset.univ.sort (· ≤ ·)
-  let e : Fin indices.length ≃ I :=
-    List.Nodup.getEquivOfForallMemList indices
-      (by simp [indices])
-      (by intro i; simp [indices])
-  (finPi indices.length (fun j => laws (e j))).map
-    (e.piCongr fun _ => Equiv.refl _)
-
 private lemma piCongr_refl_apply
     {I J : Type*} (e : I ≃ J) (X : J → Type*)
     (tuple : (i : I) → X (e i)) (i : I) :
@@ -280,9 +262,27 @@ private lemma piCongr_refl_apply
       (fun j => Equiv.refl (X (e j)))).symm_apply_apply tuple) i
   simpa only [Equiv.piCongr_symm_apply] using h
 
+section FintypeProducts
+
+variable {I : Type*} [Fintype I] [LinearOrder I] {X : I → Type uα}
+
+/-- Independent product over an explicitly enumerable finite index type.
+
+The supplied linear order turns `Fintype.elems` into an executable sorted
+enumeration; no classical `Fintype.equivFin` choice is used. -/
+def fintypePi
+    (laws : (i : I) → FiniteLaw (X i)) :
+    FiniteLaw ((i : I) → X i) :=
+  let indices : List I := Finset.univ.sort (· ≤ ·)
+  let e : Fin indices.length ≃ I :=
+    List.Nodup.getEquivOfForallMemList indices
+      (by simp [indices])
+      (by intro i; simp [indices])
+  (finPi indices.length (fun j => laws (e j))).map
+    (e.piCongr fun _ => Equiv.refl _)
+
 /-- Arbitrary finite independent products commute with coordinatewise maps. -/
-lemma fintypePi_map {I : Type*} [Fintype I] [LinearOrder I]
-    {X : I → Type uα} {Y : I → Type uβ}
+lemma fintypePi_map {Y : I → Type uβ}
     (laws : (i : I) → FiniteLaw (X i))
     (f : (i : I) → X i → Y i) :
     (fintypePi laws).map (fun tuple i => f i (tuple i)) =
@@ -340,8 +340,7 @@ lemma fintypePi_map {I : Type*} [Fintype I] [LinearOrder I]
 
 /-- Arbitrary finite independent point masses give the point mass on the
 complete tuple. -/
-lemma fintypePi_pure {I : Type*} [Fintype I] [LinearOrder I]
-    {X : I → Type uα} (tuple : (i : I) → X i) :
+lemma fintypePi_pure (tuple : (i : I) → X i) :
     fintypePi (fun i => pure (tuple i)) = pure tuple := by
   let indices : List I := Finset.univ.sort (· ≤ ·)
   let e : Fin indices.length ≃ I :=
@@ -646,9 +645,12 @@ theorem fintypePi_reindex
   intro i
   congr 2
 
+section PrefixMarginals
+
+variable {k : ℕ} {X : Fin k → Type uα}
+variable (laws : (i : Fin k) → FiniteLaw (X i))
+
 private lemma expectRat_finPiFrom_lt
-    {k : ℕ} {X : Fin k → Type uα}
-    (laws : (i : Fin k) → FiniteLaw (X i))
     (remaining count : ℕ) (htotal : count + remaining = k)
     (acc : FinPrefix X count) (i : Fin k) (hi : i.val < count)
     (value : X i → ℚ) :
@@ -678,8 +680,6 @@ private lemma expectRat_finPiFrom_lt
         _ = value (acc i hi) := expectRat_const _ _
 
 private lemma expectRat_finPiFrom_ge
-    {k : ℕ} {X : Fin k → Type uα}
-    (laws : (i : Fin k) → FiniteLaw (X i))
     (remaining count : ℕ) (htotal : count + remaining = k)
     (acc : FinPrefix X count) (i : Fin k) (hi : count ≤ i.val)
     (value : X i → ℚ) :
@@ -723,6 +723,8 @@ private lemma expectRat_finPiFrom_ge
             exact ih (count := count + 1) (htotal := by omega)
               (acc := acc.snoc (by omega) sampled) (i := i) hnext value
           _ = (laws i).expectRat value := expectRat_const _ _
+
+end PrefixMarginals
 
 /-- Every coordinate of the finite dependent product has the declared exact
 marginal law. -/

--- a/EconCSLib/Math/Probability/FiniteLaw/Product.lean
+++ b/EconCSLib/Math/Probability/FiniteLaw/Product.lean
@@ -1,0 +1,775 @@
+/-
+Copyright (c) 2026 EconCSLib contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+
+import EconCSLib.Math.Probability.FiniteLaw.Core
+import Mathlib.Data.Finset.Sort
+import Mathlib.Data.List.NodupEquivFin
+
+/-!
+# Finite products of executable laws
+
+This module constructs independent products by a fixed finite sampling order.
+Use `finPi` for a dependent `Fin k` family and `fintypePi` for a family
+with an explicit finite enumeration and linear order. The `FinPrefix` and
+`finPiFrom` helpers expose the induction invariant used to prove product
+identities; callers constructing a complete law normally use the two completed
+product operations.
+
+## Main definitions
+
+* `FiniteLaw.independentPair`;
+* `FiniteLaw.finPi` and `FiniteLaw.fintypePi`.
+
+## Main statements
+
+* `FiniteLaw.fintypePi_mass` gives the product formula for point masses;
+* `FiniteLaw.fintypePi_reindex` makes enumeration order semantically irrelevant;
+* `FiniteLaw.fintypePi_map_apply` recovers each coordinate marginal.
+-/
+
+namespace FiniteLaw
+
+universe uα uβ
+
+/-! ## Sampling pairs and dependent finite tuples -/
+
+section FinProducts
+
+variable {α β : Type*}
+
+/-- Independent product of two finite laws, sampling the left component
+first. -/
+def independentPair (left : FiniteLaw α) (right : FiniteLaw β) :
+    FiniteLaw (α × β) :=
+  left.bind fun leftValue =>
+    right.map fun rightValue => (leftValue, rightValue)
+
+/-- Values already sampled below a numeric coordinate bound. -/
+def FinPrefix {k : ℕ} (X : Fin k → Type uα)
+    (count : ℕ) : Type uα :=
+  (i : Fin k) → i.val < count → X i
+
+namespace FinPrefix
+
+variable {k : ℕ} {X : Fin k → Type uα}
+
+/-- The empty dependent prefix. -/
+def empty :
+    FinPrefix X 0 :=
+  fun i hi => (Nat.not_lt_zero i.val hi).elim
+
+/-- Append the value at the next numeric coordinate. -/
+def snoc
+    {count : ℕ} (acc : FinPrefix X count)
+    (hcount : count < k) (value : X ⟨count, hcount⟩) :
+    FinPrefix X (count + 1) :=
+  fun i hi =>
+    if hprevious : i.val < count then
+      acc i hprevious
+    else
+      have hvalue : i.val = count :=
+        Nat.eq_of_lt_succ_of_not_lt hi hprevious
+      have hindex : i = (⟨count, hcount⟩ : Fin k) :=
+        Fin.ext hvalue
+      hindex ▸ value
+
+/-- Complete a prefix covering every coordinate. -/
+def complete
+    {count : ℕ} (acc : FinPrefix X count)
+    (hcount : count = k) :
+    (i : Fin k) → X i :=
+  fun i => acc i (by omega)
+
+/-- Restrict a complete tuple to a prefix. -/
+def ofTuple
+    (tuple : (i : Fin k) → X i) (count : ℕ) :
+    FinPrefix X count :=
+  fun i _ => tuple i
+
+/-- Map every stored coordinate of a dependent prefix. -/
+def map
+    {Y : Fin k → Type uβ}
+    (f : (i : Fin k) → X i → Y i)
+    {count : ℕ} (acc : FinPrefix X count) :
+    FinPrefix Y count :=
+  fun i hi => f i (acc i hi)
+
+@[simp]
+lemma map_empty
+    {Y : Fin k → Type uβ}
+    (f : (i : Fin k) → X i → Y i) :
+    map f (empty (X := X)) = empty (X := Y) := by
+  funext i hi
+  exact (Nat.not_lt_zero i.val hi).elim
+
+@[simp]
+lemma snoc_ofTuple
+    (tuple : (i : Fin k) → X i) {count : ℕ}
+    (hcount : count < k) :
+    (ofTuple tuple count).snoc hcount
+        (tuple ⟨count, hcount⟩) =
+      ofTuple tuple (count + 1) := by
+  funext i hi
+  by_cases hprevious : i.val < count
+  · simp [snoc, ofTuple, hprevious]
+  · have hvalue : i.val = count := by omega
+    have hindex : i = (⟨count, hcount⟩ : Fin k) := Fin.ext hvalue
+    subst i
+    simp [snoc, ofTuple]
+
+@[simp]
+lemma map_snoc
+    {Y : Fin k → Type uβ}
+    (f : (i : Fin k) → X i → Y i)
+    {count : ℕ} (acc : FinPrefix X count)
+    (hcount : count < k)
+    (value : X ⟨count, hcount⟩) :
+    map f (acc.snoc hcount value) =
+      (map f acc).snoc hcount (f ⟨count, hcount⟩ value) := by
+  funext i hi
+  by_cases hprevious : i.val < count
+  · simp [map, snoc, hprevious]
+  · have hvalue : i.val = count := by omega
+    have hindex : i = (⟨count, hcount⟩ : Fin k) := Fin.ext hvalue
+    subst i
+    simp [map, snoc]
+
+@[simp]
+lemma map_complete
+    {Y : Fin k → Type uβ}
+    (f : (i : Fin k) → X i → Y i)
+    {count : ℕ} (acc : FinPrefix X count)
+    (hcount : count = k) :
+    (map f acc).complete hcount =
+      fun i => f i (acc.complete hcount i) := by
+  funext i
+  rfl
+
+end FinPrefix
+
+/-- Independently sample the remaining coordinates after a fixed prefix. -/
+def finPiFrom {k : ℕ} {X : Fin k → Type uα}
+    (laws : (i : Fin k) → FiniteLaw (X i)) :
+    (remaining count : ℕ) →
+      count + remaining = k →
+      FinPrefix X count →
+      FiniteLaw ((i : Fin k) → X i)
+  | 0, _, htotal, acc =>
+      pure (acc.complete (by omega))
+  | remaining + 1, count, htotal, acc =>
+      have hcount : count < k := by omega
+      (laws ⟨count, hcount⟩).bind fun value =>
+        finPiFrom laws remaining (count + 1) (by omega)
+          (acc.snoc hcount value)
+
+/-- Independent product of a finite dependent family.
+
+Coordinates are processed in increasing `Fin` order. No `Fintype` instance
+for the completed function space and no equality on coordinate values is
+required. -/
+def finPi (k : ℕ) {X : Fin k → Type uα}
+    (laws : (i : Fin k) → FiniteLaw (X i)) :
+    FiniteLaw ((i : Fin k) → X i) :=
+  finPiFrom laws k 0 (by omega) FinPrefix.empty
+
+/-- Independent point-mass coordinates give the point mass on the complete
+dependent tuple. -/
+lemma finPiFrom_pure {k : ℕ} {X : Fin k → Type uα}
+    (tuple : (i : Fin k) → X i) :
+    ∀ (remaining count : ℕ)
+      (htotal : count + remaining = k),
+      finPiFrom (fun i => pure (tuple i))
+          remaining count htotal
+          (FinPrefix.ofTuple tuple count) =
+        pure tuple := by
+  intro remaining
+  induction remaining with
+  | zero =>
+      intro count htotal
+      rw [finPiFrom]
+      congr
+  | succ remaining ih =>
+      intro count htotal
+      rw [finPiFrom, pure_bind, FinPrefix.snoc_ofTuple]
+      exact ih (count + 1) (by omega)
+
+/-- The independent product of point-mass laws is the point mass on the
+corresponding tuple. -/
+lemma finPi_pure (k : ℕ) {X : Fin k → Type uα}
+    (tuple : (i : Fin k) → X i) :
+    finPi k (fun i => pure (tuple i)) = pure tuple := by
+  unfold finPi
+  have hprefix :
+      (FinPrefix.empty (X := X)) =
+        FinPrefix.ofTuple tuple 0 := by
+    funext i hi
+    exact (Nat.not_lt_zero i.val hi).elim
+  rw [hprefix]
+  exact finPiFrom_pure tuple k 0 (by omega)
+
+/-- Dependent finite products commute with coordinatewise maps. -/
+lemma finPiFrom_map {k : ℕ}
+    {X : Fin k → Type uα} {Y : Fin k → Type uβ}
+    (laws : (i : Fin k) → FiniteLaw (X i))
+    (f : (i : Fin k) → X i → Y i) :
+    ∀ (remaining count : ℕ)
+      (htotal : count + remaining = k)
+      (acc : FinPrefix X count),
+      (finPiFrom laws remaining count htotal acc).map
+          (fun tuple i => f i (tuple i)) =
+        finPiFrom (fun i => (laws i).map (f i))
+          remaining count htotal (acc.map f) := by
+  intro remaining
+  induction remaining with
+  | zero =>
+      intro count htotal acc
+      rw [finPiFrom, pure_map, finPiFrom]
+      congr
+  | succ remaining ih =>
+      intro count htotal acc
+      rw [finPiFrom, map_bind, finPiFrom, bind_map]
+      congr 1
+      funext value
+      rw [ih]
+      congr
+      exact FinPrefix.map_snoc f acc (by omega) value
+
+/-- The `Fin`-indexed independent product is natural under coordinatewise
+maps. -/
+lemma finPi_map (k : ℕ)
+    {X : Fin k → Type uα} {Y : Fin k → Type uβ}
+    (laws : (i : Fin k) → FiniteLaw (X i))
+    (f : (i : Fin k) → X i → Y i) :
+    (finPi k laws).map (fun tuple i => f i (tuple i)) =
+      finPi k (fun i => (laws i).map (f i)) := by
+  unfold finPi
+  rw [finPiFrom_map]
+  simp
+
+end FinProducts
+
+/-! ## Products indexed by an ordered finite type -/
+
+section FintypeProducts
+
+/-- Independent product over an explicitly enumerable finite index type.
+
+The supplied linear order turns `Fintype.elems` into an executable sorted
+enumeration; no classical `Fintype.equivFin` choice is used. -/
+def fintypePi {I : Type*} [Fintype I] [LinearOrder I]
+    {X : I → Type uα}
+    (laws : (i : I) → FiniteLaw (X i)) :
+    FiniteLaw ((i : I) → X i) :=
+  let indices : List I := Finset.univ.sort (· ≤ ·)
+  let e : Fin indices.length ≃ I :=
+    List.Nodup.getEquivOfForallMemList indices
+      (by simp [indices])
+      (by intro i; simp [indices])
+  (finPi indices.length (fun j => laws (e j))).map
+    (e.piCongr fun _ => Equiv.refl _)
+
+private lemma piCongr_refl_apply
+    {I J : Type*} (e : I ≃ J) (X : J → Type*)
+    (tuple : (i : I) → X (e i)) (i : I) :
+    (e.piCongr (fun j => Equiv.refl (X (e j))) tuple) (e i) =
+      tuple i := by
+  have h := congrFun
+    ((e.piCongr
+      (fun j => Equiv.refl (X (e j)))).symm_apply_apply tuple) i
+  simpa only [Equiv.piCongr_symm_apply] using h
+
+/-- Arbitrary finite independent products commute with coordinatewise maps. -/
+lemma fintypePi_map {I : Type*} [Fintype I] [LinearOrder I]
+    {X : I → Type uα} {Y : I → Type uβ}
+    (laws : (i : I) → FiniteLaw (X i))
+    (f : (i : I) → X i → Y i) :
+    (fintypePi laws).map (fun tuple i => f i (tuple i)) =
+      fintypePi (fun i => (laws i).map (f i)) := by
+  let indices : List I := Finset.univ.sort (· ≤ ·)
+  let e : Fin indices.length ≃ I :=
+    List.Nodup.getEquivOfForallMemList indices
+      (by simp [indices])
+      (by intro i; simp [indices])
+  let reindexX :
+      ((j : Fin indices.length) → X (e j)) →
+        ((i : I) → X i) :=
+    e.piCongr fun _ => Equiv.refl _
+  let reindexY :
+      ((j : Fin indices.length) → Y (e j)) →
+        ((i : I) → Y i) :=
+    e.piCongr fun _ => Equiv.refl _
+  let mapFin :
+      ((j : Fin indices.length) → X (e j)) →
+        ((j : Fin indices.length) → Y (e j)) :=
+    fun tuple j => f (e j) (tuple j)
+  let mapIndex : ((i : I) → X i) → ((i : I) → Y i) :=
+    fun tuple i => f i (tuple i)
+  change
+    ((finPi indices.length
+        (fun j => laws (e j))).map reindexX).map mapIndex =
+      (finPi indices.length
+        (fun j => (laws (e j)).map (f (e j)))).map reindexY
+  calc
+    ((finPi indices.length
+        (fun j => laws (e j))).map reindexX).map mapIndex =
+        (finPi indices.length
+          (fun j => laws (e j))).map (mapIndex ∘ reindexX) :=
+      map_comp reindexX _ mapIndex
+    _ = (finPi indices.length
+          (fun j => laws (e j))).map (reindexY ∘ mapFin) := by
+      congr 1
+      funext tuple i
+      change
+        f i
+            ((e.piCongr
+              (fun j => Equiv.refl (X (e j))) tuple) i) =
+          (e.piCongr
+            (fun j => Equiv.refl (Y (e j)))
+            (fun j => f (e j) (tuple j))) i
+      let j := e.symm i
+      have hindex : e j = i := e.apply_symm_apply i
+      rw [← hindex, piCongr_refl_apply, piCongr_refl_apply]
+    _ = ((finPi indices.length
+          (fun j => laws (e j))).map mapFin).map reindexY :=
+      (map_comp mapFin _ reindexY).symm
+    _ = (finPi indices.length
+          (fun j => (laws (e j)).map (f (e j)))).map reindexY := by
+      rw [finPi_map]
+
+/-- Arbitrary finite independent point masses give the point mass on the
+complete tuple. -/
+lemma fintypePi_pure {I : Type*} [Fintype I] [LinearOrder I]
+    {X : I → Type uα} (tuple : (i : I) → X i) :
+    fintypePi (fun i => pure (tuple i)) = pure tuple := by
+  let indices : List I := Finset.univ.sort (· ≤ ·)
+  let e : Fin indices.length ≃ I :=
+    List.Nodup.getEquivOfForallMemList indices
+      (by simp [indices])
+      (by intro i; simp [indices])
+  let reindex :
+      ((j : Fin indices.length) → X (e j)) →
+        ((i : I) → X i) :=
+    e.piCongr fun _ => Equiv.refl _
+  change
+    (finPi indices.length
+      (fun j => pure (tuple (e j)))).map reindex = pure tuple
+  rw [finPi_pure, pure_map]
+  congr
+  funext i
+  change
+    (e.piCongr
+      (fun j => Equiv.refl (X (e j)))
+      (fun j => tuple (e j))) i = tuple i
+  let j := e.symm i
+  have hindex : e j = i := e.apply_symm_apply i
+  rw [← hindex, piCongr_refl_apply]
+
+end FintypeProducts
+
+/-! ## Positive atoms and the product mass formula -/
+
+section ProductMass
+
+/-- Every positive outcome of a completion law extends its fixed prefix. -/
+lemma finPiFrom_apply_eq_of_hasPositiveAtom_of_lt
+    {k : ℕ} {X : Fin k → Type uα}
+    (laws : (i : Fin k) → FiniteLaw (X i)) :
+    ∀ (remaining count : ℕ)
+      (htotal : count + remaining = k)
+      (acc : FinPrefix X count)
+      (outcome : (i : Fin k) → X i),
+      (finPiFrom laws remaining count htotal acc).HasPositiveAtom outcome →
+      ∀ (i : Fin k) (hi : i.val < count),
+        outcome i = acc i hi := by
+  intro remaining
+  induction remaining with
+  | zero =>
+      intro count htotal acc outcome houtcome i hi
+      simp only [finPiFrom] at houtcome
+      have houtcomeEq := (hasPositiveAtom_pure_iff _ _).mp houtcome
+      subst outcome
+      rfl
+  | succ remaining ih =>
+      intro count htotal acc outcome houtcome i hi
+      simp only [finPiFrom] at houtcome
+      obtain ⟨value, _, houtcome⟩ :=
+        (hasPositiveAtom_bind_iff _ _ _).mp houtcome
+      have hnext : i.val < count + 1 := by omega
+      rw [ih (count + 1) (by omega)
+        (acc.snoc (by omega) value) outcome houtcome i hnext]
+      simp [FinPrefix.snoc, hi]
+
+private def finPiMassFrom {k : ℕ} {X : Fin k → Type uα}
+    [∀ i, DecidableEq (X i)]
+    (laws : (i : Fin k) → FiniteLaw (X i))
+    (tuple : (i : Fin k) → X i) :
+    (remaining count : ℕ) → count + remaining = k → ℚ≥0
+  | 0, _, _ => 1
+  | remaining + 1, count, htotal =>
+      (laws ⟨count, by omega⟩).mass (tuple ⟨count, by omega⟩) *
+        finPiMassFrom laws tuple remaining (count + 1) (by omega)
+
+private lemma sum_weight_mul_indicator
+    [DecidableEq α] (law : FiniteLaw α)
+    (target : α) (constant : ℚ≥0) :
+    (law.atoms.map fun atom =>
+      atom.2 * if atom.1 = target then constant else 0).sum =
+      law.mass target * constant := by
+  unfold mass eventMass
+  induction law.atoms with
+  | nil => simp
+  | cons atom atoms ih =>
+      rcases atom with ⟨outcome, weight⟩
+      simp only [List.map_cons, List.sum_cons]
+      rw [ih]
+      by_cases heq : outcome = target
+      · simp [heq, add_mul]
+      · simp [heq]
+
+private lemma mass_map_pair_left
+    [DecidableEq α] [DecidableEq β]
+    (law : FiniteLaw β) (left : α) (target : α × β) :
+    (law.map fun right => (left, right)).mass target =
+      if left = target.1 then law.mass target.2 else 0 := by
+  rcases target with ⟨targetLeft, targetRight⟩
+  unfold mass eventMass
+  rw [map_atoms, List.map_map]
+  by_cases heq : left = targetLeft
+  · subst left
+    simp [Function.comp_def]
+  · simp [heq, Function.comp_def]
+
+/-- Point mass of an independent pair factors into the point masses of its
+two coordinates. -/
+theorem independentPair_mass
+    [DecidableEq α] [DecidableEq β]
+    (left : FiniteLaw α) (right : FiniteLaw β)
+    (target : α × β) :
+    (independentPair left right).mass target =
+      left.mass target.1 * right.mass target.2 := by
+  unfold independentPair
+  rw [mass_bind]
+  calc
+    (left.atoms.map fun atom => atom.2 *
+        (right.map fun rightValue =>
+          (atom.1, rightValue)).mass target).sum =
+        (left.atoms.map fun atom => atom.2 *
+          if atom.1 = target.1 then right.mass target.2 else 0).sum := by
+      apply congrArg List.sum
+      apply List.map_congr_left
+      intro atom _
+      rw [mass_map_pair_left]
+    _ = left.mass target.1 * right.mass target.2 :=
+      sum_weight_mul_indicator left target.1 (right.mass target.2)
+
+private lemma finPiFrom_mass_of_prefix
+    {k : ℕ} {X : Fin k → Type uα}
+    [∀ i, DecidableEq (X i)]
+    [DecidableEq ((i : Fin k) → X i)]
+    (laws : (i : Fin k) → FiniteLaw (X i))
+    (tuple : (i : Fin k) → X i) :
+    ∀ (remaining count : ℕ)
+      (htotal : count + remaining = k)
+      (acc : FinPrefix X count)
+      (_hprefix : ∀ (i : Fin k) (hi : i.val < count),
+        tuple i = acc i hi),
+      (finPiFrom laws remaining count htotal acc).mass tuple =
+        finPiMassFrom laws tuple remaining count htotal := by
+  intro remaining
+  induction remaining with
+  | zero =>
+      intro count htotal acc hprefix
+      rw [finPiFrom]
+      have htuple : acc.complete (by omega) = tuple := by
+        funext i
+        exact (hprefix i (by omega)).symm
+      simp [finPiMassFrom, htuple]
+  | succ remaining ih =>
+      intro count htotal acc hprefix
+      rw [finPiFrom, mass_bind]
+      rw [finPiMassFrom]
+      let current : Fin k := ⟨count, by omega⟩
+      let tailMass : ℚ≥0 :=
+        finPiMassFrom laws tuple remaining (count + 1) (by omega)
+      have hcontinuation (sampled : X current) :
+          (finPiFrom laws remaining (count + 1) (by omega)
+              (acc.snoc (by omega) sampled)).mass tuple =
+            if sampled = tuple current then tailMass else 0 := by
+        by_cases heq : sampled = tuple current
+        · rw [if_pos heq]
+          subst sampled
+          apply ih (count + 1) (by omega)
+          intro i hi
+          by_cases hprevious : i.val < count
+          · simp [FinPrefix.snoc, hprevious, hprefix i hprevious]
+          · have hindex : i = current := by
+              apply Fin.ext
+              simp only [current]
+              omega
+            subst i
+            simp [FinPrefix.snoc, current]
+        · rw [if_neg heq]
+          apply mass_eq_zero_of_not_hasPositiveAtom
+          intro hpositive
+          have hcurrent :=
+            finPiFrom_apply_eq_of_hasPositiveAtom_of_lt
+              laws remaining (count + 1) (by omega)
+              (acc.snoc (by omega) sampled) tuple hpositive
+              current (by simp [current])
+          apply heq
+          simpa [FinPrefix.snoc, current] using hcurrent.symm
+      calc
+        (List.map
+            (fun atom =>
+              atom.2 *
+                (finPiFrom laws remaining (count + 1) (by omega)
+                  (acc.snoc (by omega) atom.1)).mass tuple)
+            (laws current).atoms).sum =
+            (List.map
+              (fun atom => atom.2 *
+                if atom.1 = tuple current then tailMass else 0)
+              (laws current).atoms).sum := by
+          apply congrArg List.sum
+          apply List.map_congr_left
+          intro atom _
+          rw [hcontinuation atom.1]
+        _ = (laws current).mass (tuple current) * tailMass :=
+          sum_weight_mul_indicator (laws current) (tuple current) tailMass
+        _ = _ := rfl
+
+/-- The point mass of a `Fin`-indexed independent product is the recursive
+product of its coordinate masses in increasing index order. -/
+theorem finPi_mass (k : ℕ) {X : Fin k → Type uα}
+    [∀ i, DecidableEq (X i)]
+    [DecidableEq ((i : Fin k) → X i)]
+    (laws : (i : Fin k) → FiniteLaw (X i))
+    (tuple : (i : Fin k) → X i) :
+    (finPi k laws).mass tuple =
+      finPiMassFrom laws tuple k 0 (by omega) := by
+  unfold finPi
+  exact finPiFrom_mass_of_prefix laws tuple k 0 (by omega)
+    FinPrefix.empty (by intro i hi; omega)
+
+private lemma finPiMassFrom_eq_prod
+    {k : ℕ} {X : Fin k → Type uα}
+    [∀ i, DecidableEq (X i)]
+    (laws : (i : Fin k) → FiniteLaw (X i))
+    (tuple : (i : Fin k) → X i) :
+    ∀ (remaining count : ℕ) (htotal : count + remaining = k),
+      finPiMassFrom laws tuple remaining count htotal =
+        ∏ i ∈ (Finset.univ.filter fun i : Fin k => count ≤ i.val),
+          (laws i).mass (tuple i) := by
+  intro remaining
+  induction remaining with
+  | zero =>
+      intro count htotal
+      rw [finPiMassFrom]
+      apply (Finset.prod_eq_one ?_).symm
+      intro i hi
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hi
+      omega
+  | succ remaining ih =>
+      intro count htotal
+      rw [finPiMassFrom]
+      let current : Fin k := ⟨count, by omega⟩
+      have hfilter :
+          (Finset.univ.filter fun i : Fin k => count ≤ i.val) =
+            insert current
+              (Finset.univ.filter fun i : Fin k => count + 1 ≤ i.val) := by
+        ext i
+        simp only [Finset.mem_filter, Finset.mem_univ, true_and,
+          Finset.mem_insert]
+        constructor
+        · intro hi
+          by_cases heq : i.val = count
+          · exact Or.inl (Fin.ext heq)
+          · exact Or.inr (by omega)
+        · rintro (heq | hi)
+          · subst i
+            simp [current]
+          · omega
+      rw [hfilter, Finset.prod_insert]
+      · rw [ih (count + 1) (by omega)]
+      · simp [current]
+
+/-- Point mass of an arbitrary finite dependent product is the commutative
+product of its coordinate point masses. -/
+theorem fintypePi_mass {I : Type*} [Fintype I] [LinearOrder I]
+    {X : I → Type uα}
+    [∀ i, DecidableEq (X i)]
+    [DecidableEq ((i : I) → X i)]
+    (laws : (i : I) → FiniteLaw (X i))
+    (tuple : (i : I) → X i) :
+    (fintypePi laws).mass tuple =
+      ∏ i, (laws i).mass (tuple i) := by
+  let indices : List I := Finset.univ.sort (· ≤ ·)
+  let e : Fin indices.length ≃ I :=
+    List.Nodup.getEquivOfForallMemList indices
+      (by simp [indices])
+      (by intro i; simp [indices])
+  let reindex :
+      ((j : Fin indices.length) → X (e j)) →
+        ((i : I) → X i) :=
+    e.piCongr fun _ => Equiv.refl _
+  change
+    ((finPi indices.length
+      (fun j => laws (e j))).map reindex).mass tuple = _
+  rw [mass_map_equiv, finPi_mass, finPiMassFrom_eq_prod]
+  simp only [Nat.zero_le, Finset.filter_true]
+  apply Fintype.prod_equiv e
+  intro j
+  congr 2
+
+end ProductMass
+
+/-! ## Reindexing and coordinate marginals -/
+
+section Marginals
+
+/-- Reindexing an independent finite product along an equivalence preserves
+its exact distribution, although the sparse atom order may change. -/
+theorem fintypePi_reindex
+    {I J : Type*} [Fintype I] [LinearOrder I]
+    [Fintype J] [LinearOrder J]
+    (e : I ≃ J) {X : J → Type uα}
+    (laws : (j : J) → FiniteLaw (X j)) :
+    ((fintypePi (fun i : I => laws (e i))).map
+      (e.piCongr fun _ => Equiv.refl _)).Equivalent
+        (fintypePi laws) := by
+  classical
+  apply Equivalent.of_mass_eq
+  intro tuple
+  rw [mass_map_equiv, fintypePi_mass, fintypePi_mass]
+  apply Fintype.prod_equiv e
+  intro i
+  congr 2
+
+private lemma expectRat_finPiFrom_lt
+    {k : ℕ} {X : Fin k → Type uα}
+    (laws : (i : Fin k) → FiniteLaw (X i))
+    (remaining count : ℕ) (htotal : count + remaining = k)
+    (acc : FinPrefix X count) (i : Fin k) (hi : i.val < count)
+    (value : X i → ℚ) :
+    (finPiFrom laws remaining count htotal acc).expectRat
+        (fun outcome => value (outcome i)) =
+      value (acc i hi) := by
+  induction remaining generalizing count i value with
+  | zero =>
+      simp only [finPiFrom, expectRat_pure]
+      rfl
+  | succ remaining ih =>
+      simp only [finPiFrom, expectRat_bind]
+      calc
+        (laws ⟨count, by omega⟩).expectRat
+            (fun sampled =>
+              (finPiFrom laws remaining (count + 1) (by omega)
+                  (acc.snoc (by omega) sampled)).expectRat
+                (fun outcome => value (outcome i))) =
+            (laws ⟨count, by omega⟩).expectRat
+              (fun _ => value (acc i hi)) := by
+          congr 1
+          funext sampled
+          rw [ih (count := count + 1) (htotal := by omega)
+            (acc := acc.snoc (by omega) sampled) (hi := by omega)]
+          congr 1
+          simp [FinPrefix.snoc, hi]
+        _ = value (acc i hi) := expectRat_const _ _
+
+private lemma expectRat_finPiFrom_ge
+    {k : ℕ} {X : Fin k → Type uα}
+    (laws : (i : Fin k) → FiniteLaw (X i))
+    (remaining count : ℕ) (htotal : count + remaining = k)
+    (acc : FinPrefix X count) (i : Fin k) (hi : count ≤ i.val)
+    (value : X i → ℚ) :
+    (finPiFrom laws remaining count htotal acc).expectRat
+        (fun outcome => value (outcome i)) =
+      (laws i).expectRat value := by
+  induction remaining generalizing count i value with
+  | zero => omega
+  | succ remaining ih =>
+      simp only [finPiFrom, expectRat_bind]
+      by_cases hcurrent : i.val = count
+      · rcases i with ⟨index, hindex⟩
+        simp only at hcurrent
+        subst index
+        calc
+          (laws ⟨count, hindex⟩).expectRat
+              (fun sampled =>
+                (finPiFrom laws remaining (count + 1) (by omega)
+                    (acc.snoc hindex sampled)).expectRat
+                  (fun outcome => value (outcome ⟨count, hindex⟩))) =
+              (laws ⟨count, hindex⟩).expectRat value := by
+            congr 1
+            funext sampled
+            rw [expectRat_finPiFrom_lt laws remaining (count + 1)
+              (by omega) (acc.snoc hindex sampled)
+              ⟨count, hindex⟩ (Nat.lt_succ_self count) value]
+            congr 1
+            simp [FinPrefix.snoc]
+          _ = (laws ⟨count, hindex⟩).expectRat value := rfl
+      · have hnext : count + 1 ≤ i.val := by omega
+        calc
+          (laws ⟨count, by omega⟩).expectRat
+              (fun sampled =>
+                (finPiFrom laws remaining (count + 1) (by omega)
+                    (acc.snoc (by omega) sampled)).expectRat
+                  (fun outcome => value (outcome i))) =
+              (laws ⟨count, by omega⟩).expectRat
+                (fun _ => (laws i).expectRat value) := by
+            congr 1
+            funext sampled
+            exact ih (count := count + 1) (htotal := by omega)
+              (acc := acc.snoc (by omega) sampled) (i := i) hnext value
+          _ = (laws i).expectRat value := expectRat_const _ _
+
+/-- Every coordinate of the finite dependent product has the declared exact
+marginal law. -/
+theorem finPi_map_apply
+    (k : ℕ) {X : Fin k → Type uα}
+    (laws : (i : Fin k) → FiniteLaw (X i)) (i : Fin k) :
+    ((finPi k laws).map fun outcome => outcome i).Equivalent (laws i) := by
+  intro value
+  change
+    ((finPi k laws).map fun outcome => outcome i).expectRat value =
+      (laws i).expectRat value
+  rw [expectRat_map]
+  exact expectRat_finPiFrom_ge laws k 0 (by omega)
+    FinPrefix.empty i (by omega) value
+
+/-- Every coordinate of an arbitrary finite dependent product has the
+declared exact marginal law. -/
+theorem fintypePi_map_apply {I : Type*} [Fintype I] [LinearOrder I]
+    {X : I → Type uα} (laws : (i : I) → FiniteLaw (X i)) (i : I) :
+    ((fintypePi laws).map fun outcome => outcome i).Equivalent (laws i) := by
+  let indices : List I := Finset.univ.sort (· ≤ ·)
+  let e : Fin indices.length ≃ I :=
+    List.Nodup.getEquivOfForallMemList indices
+      (by simp [indices])
+      (by intro target; simp [indices])
+  let reindex :
+      ((j : Fin indices.length) → X (e j)) →
+        ((target : I) → X target) :=
+    e.piCongr fun _ => Equiv.refl _
+  let j := e.symm i
+  have hindex : e j = i := e.apply_symm_apply i
+  change
+    (((finPi indices.length (fun coordinate => laws (e coordinate))).map
+        reindex).map fun outcome => outcome i).Equivalent (laws i)
+  rw [← hindex, map_comp]
+  have hmap :
+      (fun outcome => outcome (e j)) ∘ reindex =
+        fun outcome => outcome j := by
+    funext outcome
+    change
+      (e.piCongr
+        (fun coordinate => Equiv.refl (X (e coordinate))) outcome) (e j) =
+        outcome j
+    rw [piCongr_refl_apply]
+  rw [hmap]
+  exact finPi_map_apply indices.length (fun coordinate => laws (e coordinate)) j
+
+end Marginals
+
+end FiniteLaw

--- a/EconCSLib/Math/Probability/FiniteMarkovChain.lean
+++ b/EconCSLib/Math/Probability/FiniteMarkovChain.lean
@@ -1,0 +1,471 @@
+/-
+Copyright (c) 2026 EconCSLib contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+
+import EconCSLib.Math.Probability.FiniteLaw
+import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
+
+/-!
+# Exact finite absorbing Markov-chain computation
+
+Reusable exact finite-chain algorithms. Transient and terminal states have
+explicit `Fin` encodings. Nonnegative rational rows sum to one, and terminal states
+are absorbing. This is a Markov specification, not an EFG history quotient:
+there is no assertion that an arbitrary EFG endpoint contains enough memory.
+
+`run` computes censored first-hit data by the original transition rows.
+`admissible` checks a finite-step absorption bound. `solve` uses executable
+rational determinants and Cramer's rule, returning an explicit error if the
+bound fails or the linear system is singular. `autoCheck` enumerates the full
+transient domain at horizon `n+1`, and `autoSolve` computes its exact bound
+before invoking that solver. Analytic correctness is proved separately in
+`FiniteMarkovChain.Semantics`, keeping this executable module free of measure
+and integral dependencies.
+
+## Reading order
+
+Transition rows lead to the `run_expect` specification of finite execution.
+A supplied absorption bound supports exact Bellman solving. Survival lemmas
+then establish finite reachability completeness and the automatic checker.
+Routine lemmas support these main theorems without additional model fields.
+-/
+
+namespace FiniteMarkovChain
+
+open Matrix
+open scoped BigOperators
+
+/-- A fixed finite chain with transient block `Q`, terminal block `R`, and
+state-dependent terminal reward. All fields are data except normalization. -/
+structure Chain (n m : ℕ) where
+  /-- Transient-to-transient probabilities. -/
+  transient : Matrix (Fin n) (Fin n) ℚ≥0
+  /-- Transient-to-terminal probabilities. -/
+  terminal : Matrix (Fin n) (Fin m) ℚ≥0
+  /-- Each complete transient row is a probability distribution. -/
+  normalized : ∀ i, (∑ j, transient i j) + (∑ a, terminal i a) = 1
+  /-- Original payoff at each terminal state. -/
+  reward : Fin m → ℚ
+
+namespace Chain
+
+variable {n m : ℕ} (C : Chain n m)
+
+/-! ## Transition rows -/
+
+section TransitionRows
+
+/-- Rational transient matrix used in the linear systems. -/
+def Q : Matrix (Fin n) (Fin n) ℚ := fun i j => C.transient i j
+
+/-- Rational terminal matrix used in the linear systems. -/
+def R : Matrix (Fin n) (Fin m) ℚ := fun i a => C.terminal i a
+
+/-- The actual normalized row, enumerating every transient and terminal state. -/
+def row (i : Fin n) : FiniteLaw (Fin n ⊕ Fin m) where
+  atoms := (List.ofFn fun j => (Sum.inl j, C.transient i j)) ++
+    (List.ofFn fun a => (Sum.inr a, C.terminal i a))
+  normalized := by
+    simpa only [List.map_append, List.map_map, Function.comp_def, List.sum_append,
+      List.sum_ofFn, List.map_ofFn] using C.normalized i
+
+/-- Terminal states stutter; transient states use their fixed transition row. -/
+def step : (Fin n ⊕ Fin m) → FiniteLaw (Fin n ⊕ Fin m)
+  | .inl i => C.row i
+  | .inr a => FiniteLaw.pure (.inr a)
+
+/-- Exact one-step expectation, separating the two matrix blocks. -/
+lemma expectRat_row (i : Fin n) (f : (Fin n ⊕ Fin m) → ℚ) :
+    (C.row i).expectRat f =
+      (∑ j, C.Q i j * f (.inl j)) + ∑ a, C.R i a * f (.inr a) := by
+  simp [row, FiniteLaw.expectRat, Q, R, Function.comp_def,
+    List.map_ofFn, List.sum_ofFn]
+
+/-- Nonnegative entries of the transient block. -/
+lemma Q_nonneg (i j : Fin n) : 0 ≤ C.Q i j := (C.transient i j).property
+
+/-- Nonnegative entries of the terminal block. -/
+lemma R_nonneg (i : Fin n) (a : Fin m) : 0 ≤ C.R i a := (C.terminal i a).property
+
+/-- Rational row normalization is inherited from the actual probability data. -/
+lemma row_sum (i : Fin n) : (∑ j, C.Q i j) + (∑ a, C.R i a) = 1 := by
+  dsimp [Q, R]
+  exact_mod_cast C.normalized i
+
+end TransitionRows
+
+/-! ## Censored finite execution -/
+
+section FiniteExecution
+
+/-- A censored result is a still-active state or the first terminal state
+and the number of preceding transient transitions. Hitting time is `r + 1`. -/
+abbrev Result (n m : ℕ) := Fin n ⊕ (ℕ × Fin m)
+
+/-- Retain a first hit while counting one additional earlier transition. -/
+def delay : Result n m → Result n m
+  | .inl i => .inl i
+  | .inr (r, a) => .inr (r + 1, a)
+
+/-- Execute at most `horizon` transitions from a transient state. A result
+`inl` means only that the horizon ended before a hit. -/
+def run : ℕ → Fin n → FiniteLaw (Result n m)
+  | 0, i => FiniteLaw.pure (.inl i)
+  | horizon + 1, i => (C.row i).bind fun state => match state with
+    | .inl j => (run horizon j).map delay
+    | .inr a => FiniteLaw.pure (.inr (0, a))
+
+/-- First-hit coefficients: terminate after `r` transient transitions. -/
+def hit (r : ℕ) : Matrix (Fin n) (Fin m) ℚ := C.Q ^ r * C.R
+
+/-- Every transient path coefficient is nonnegative. -/
+lemma pow_nonneg (r : ℕ) (i j : Fin n) : 0 ≤ (C.Q ^ r) i j :=
+  Matrix.pow_apply_nonneg C.Q_nonneg r i j
+
+/-- Every first-hit coefficient is nonnegative. -/
+lemma hit_nonneg (r : ℕ) (i : Fin n) (a : Fin m) : 0 ≤ C.hit r i a :=
+  Finset.sum_nonneg fun j _ => mul_nonneg (C.pow_nonneg r i j) (C.R_nonneg j a)
+
+private lemma observe_delay (active : Fin n → ℚ) (finished : ℕ → Fin m → ℚ) :
+    (Sum.elim active (fun x => finished x.1 x.2)) ∘ delay =
+      Sum.elim active (fun x => finished (x.1 + 1) x.2) := by
+  funext result
+  cases result with
+  | inl i => rfl
+  | inr pair => cases pair; rfl
+
+private lemma transient_step (horizon : ℕ) (i : Fin n) (active : Fin n → ℚ) :
+    (∑ j, C.Q i j * (C.Q ^ horizon *ᵥ active) j) =
+      (C.Q ^ (horizon + 1) *ᵥ active) i := by
+  change (C.Q *ᵥ (C.Q ^ horizon *ᵥ active)) i = _
+  rw [Matrix.mulVec_mulVec, pow_succ']
+
+private lemma firstHit_step (horizon : ℕ) (i : Fin n) (finished : ℕ → Fin m → ℚ) :
+    (∑ j, C.Q i j *
+      ∑ r ∈ Finset.range horizon, (C.hit r *ᵥ finished (r + 1)) j) =
+      ∑ r ∈ Finset.range horizon, (C.hit (r + 1) *ᵥ finished (r + 1)) i := by
+  simp_rw [Finset.mul_sum]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro r _
+  change (C.Q *ᵥ (C.hit r *ᵥ finished (r + 1))) i = _
+  rw [Matrix.mulVec_mulVec]
+  rw [show C.Q * C.hit r = C.hit (r + 1) by
+    simp only [hit, pow_succ', Matrix.mul_assoc]]
+
+/-- The finite executor's complete censored first-hit law, tested against any
+rational observable. The active term has not yet terminated; the sum records
+each possible first-hit time separately. -/
+theorem run_expect (horizon : ℕ) (i : Fin n)
+    (active : Fin n → ℚ) (finished : ℕ → Fin m → ℚ) :
+    (C.run horizon i).expectRat (Sum.elim active (fun x => finished x.1 x.2)) =
+      (C.Q ^ horizon *ᵥ active) i +
+        ∑ r ∈ Finset.range horizon, (C.hit r *ᵥ finished r) i := by
+  induction horizon generalizing i finished with
+  | zero => simp [run, FiniteLaw.expectRat_pure]
+  | succ horizon ih =>
+    simp only [run, FiniteLaw.expectRat_bind, C.expectRat_row,
+      FiniteLaw.expectRat_map, FiniteLaw.expectRat_pure]
+    rw [observe_delay]
+    change (∑ j, C.Q i j *
+      (C.run horizon j).expectRat
+        (Sum.elim active (fun x => finished (x.1 + 1) x.2))) +
+        ∑ a, C.R i a * finished 0 a = _
+    have ihshift (j : Fin n) := ih j (fun r a => finished (r + 1) a)
+    simp_rw [ihshift]
+    simp_rw [mul_add]
+    rw [Finset.sum_add_distrib]
+    rw [C.transient_step horizon i active, C.firstHit_step horizon i finished]
+    rw [Finset.sum_range_succ']
+    simp only [hit, pow_zero, Matrix.one_mul]
+    change _ + _ + (C.R *ᵥ finished 0) i = _
+    ring
+
+/-- Each first-hit coefficient is the probability of that concrete censored
+execution result, once the horizon includes its hit time. -/
+theorem run_firstHit (horizon r : ℕ) (hr : r < horizon) (i : Fin n) (a : Fin m) :
+    (C.run horizon i).expectRat (fun result =>
+      if result = Sum.inr (r, a) then 1 else 0) = C.hit r i a := by
+  have heq : (fun result : Result n m => if result = Sum.inr (r, a) then (1 : ℚ) else 0) =
+      Sum.elim (fun _ => 0) (fun x => if x.1 = r then if x.2 = a then 1 else 0 else 0) := by
+    funext result
+    cases result <;> simp [Prod.ext_iff, ite_and]
+  rw [heq, C.run_expect horizon i (fun _ => 0)
+    (fun s b => if s = r then if b = a then 1 else 0 else 0)]
+  simp [Matrix.mulVec, dotProduct, Finset.mem_range, hr]
+
+/-- The survival probability is the row sum of the transient power. -/
+lemma run_survival (horizon : ℕ) (i : Fin n) :
+    (C.run horizon i).expectRat (Sum.elim (fun _ => 1) (fun _ => 0)) =
+      ∑ j, (C.Q ^ horizon) i j := by
+  simpa [Matrix.mulVec, dotProduct] using
+    C.run_expect horizon i (fun _ => 1) (fun _ _ => 0)
+
+end FiniteExecution
+
+/-! ## Checking a supplied absorption bound -/
+
+section AbsorptionBound
+
+/-- A checked `k`-step survival bound. The guaranteed absorption probability
+is at least `1-c > 0` from every transient state. -/
+def admissible (k : ℕ) (c : ℚ) : Bool :=
+  decide (0 < k ∧ 0 ≤ c ∧ c < 1 ∧ ∀ i, (∑ j, (C.Q ^ k) i j) ≤ c)
+
+/-- The checker exposes exactly the finite rational inequalities it tests. -/
+lemma admissible_iff (k : ℕ) (c : ℚ) :
+    C.admissible k c = true ↔
+      0 < k ∧ 0 ≤ c ∧ c < 1 ∧ ∀ i, (∑ j, (C.Q ^ k) i j) ≤ c := by
+  simp [admissible]
+
+end AbsorptionBound
+
+/-! ## Exact Bellman solving -/
+
+section LinearSystems
+
+/-- Failure is explicit and does not assign a fictitious zero solution. -/
+inductive SolveError
+  | absorptionBound
+  | singular
+  deriving DecidableEq, Repr
+
+/-- Exact Cramer solving on the finite rational matrix, with a singularity
+test before dividing. No inverse matrix or solution is supplied by a caller. -/
+def solveLinear (A : Matrix (Fin n) (Fin n) ℚ) (b : Fin n → ℚ) :
+    Option (Fin n → ℚ) :=
+  if A.det = 0 then none else some (A.det⁻¹ • A.cramer b)
+
+/-- At a nonsingular matrix, the actual returned vector satisfies the system. -/
+lemma solveLinear_spec (A : Matrix (Fin n) (Fin n) ℚ) (b : Fin n → ℚ)
+    (hA : A.det ≠ 0) :
+    ∃ x, solveLinear A b = some x ∧ A *ᵥ x = b := by
+  refine ⟨A.det⁻¹ • A.cramer b, by simp [solveLinear, hA], ?_⟩
+  rw [Matrix.mulVec_smul, Matrix.mulVec_cramer, smul_smul, inv_mul_cancel₀ hA, one_smul]
+
+/-- The computed nonsingular solution is unique. -/
+lemma solveLinear_unique (A : Matrix (Fin n) (Fin n) ℚ) (hA : A.det ≠ 0)
+    {x y : Fin n → ℚ} (hx : A *ᵥ x = A *ᵥ y) : x = y :=
+  (Matrix.mulVec_injective_iff_isUnit.mpr
+    ((Matrix.isUnit_iff_isUnit_det A).mpr (isUnit_iff_ne_zero.mpr hA))) hx
+
+/-- Solve both Bellman systems, extending the returned vectors by `v=g`
+and `t=0` at terminal states. -/
+def solve (k : ℕ) (c : ℚ) :
+    Except SolveError (((Fin n ⊕ Fin m) → ℚ) × ((Fin n ⊕ Fin m) → ℚ)) :=
+  if C.admissible k c then
+    match solveLinear (1 - C.Q) (C.R *ᵥ C.reward),
+      solveLinear (1 - C.Q) (fun _ => 1) with
+    | some v, some t => .ok (Sum.elim v C.reward, Sum.elim t (fun _ => 0))
+    | _, _ => .error .singular
+  else .error .absorptionBound
+
+end LinearSystems
+
+/-! ## Survival probabilities -/
+
+section Survival
+
+/-- Exact unfinished probability, identified with the finite executor by
+`run_survival`. No transient state is removed from the supplied domain. -/
+def survival (horizon : ℕ) (i : Fin n) : ℚ := ∑ j, (C.Q ^ horizon) i j
+
+/-- A transient start is unfinished at time zero. -/
+lemma survival_zero (i : Fin n) : C.survival 0 i = 1 := by
+  simp [survival, Matrix.one_apply]
+
+/-- Survival evolves by the original transient transition matrix. -/
+lemma survival_succ (horizon : ℕ) (i : Fin n) :
+    C.survival (horizon + 1) i = ∑ j, C.Q i j * C.survival horizon j := by
+  simp only [survival, pow_succ', Matrix.mul_apply, Finset.mul_sum]
+  exact Finset.sum_comm
+
+/-- Unfinished probabilities are nonnegative. -/
+lemma survival_nonneg (horizon : ℕ) (i : Fin n) : 0 ≤ C.survival horizon i :=
+  Finset.sum_nonneg fun j _ => C.pow_nonneg horizon i j
+
+/-- Normalized nonnegative rows keep every survival probability at most one. -/
+lemma survival_le_one (horizon : ℕ) (i : Fin n) : C.survival horizon i ≤ 1 := by
+  induction horizon generalizing i with
+  | zero => simp [C.survival_zero]
+  | succ horizon ih =>
+    rw [C.survival_succ]
+    calc
+      _ ≤ ∑ j, C.Q i j * 1 := Finset.sum_le_sum fun j _ =>
+        mul_le_mul_of_nonneg_left (ih j) (C.Q_nonneg i j)
+      _ ≤ 1 := by
+        simp only [mul_one]
+        have := C.row_sum i
+        have := Finset.sum_nonneg (fun a (_ : a ∈ Finset.univ) => C.R_nonneg i a)
+        linarith
+
+/-- Increasing the execution horizon cannot increase unfinished mass. -/
+lemma survival_antitone (i : Fin n) : Antitone (fun horizon => C.survival horizon i) := by
+  have hstep (horizon : ℕ) : ∀ i, C.survival (horizon + 1) i ≤ C.survival horizon i := by
+    induction horizon with
+    | zero => intro i; simpa [C.survival_zero] using C.survival_le_one 1 i
+    | succ horizon ih =>
+      intro i
+      rw [C.survival_succ, C.survival_succ horizon]
+      exact Finset.sum_le_sum fun j _ => mul_le_mul_of_nonneg_left (ih j) (C.Q_nonneg i j)
+  exact antitone_nat_of_succ_le fun horizon => hstep horizon i
+
+private lemma survival_deficit (horizon : ℕ) (i : Fin n) :
+    1 - C.survival (horizon + 1) i =
+      (∑ a, C.R i a) + ∑ j, C.Q i j * (1 - C.survival horizon j) := by
+  rw [C.survival_succ]
+  simp only [mul_sub, mul_one, Finset.sum_sub_distrib]
+  linarith [C.row_sum i]
+
+/-- Positive finite-step termination means a positive immediate exit or a
+positive transient edge to a state that can terminate in the remaining steps. -/
+lemma survival_succ_lt_one_iff (horizon : ℕ) (i : Fin n) :
+    C.survival (horizon + 1) i < 1 ↔
+      (∃ a, 0 < C.R i a) ∨ ∃ j, 0 < C.Q i j ∧ C.survival horizon j < 1 := by
+  have hr := Finset.sum_nonneg (fun a (_ : a ∈ Finset.univ) => C.R_nonneg i a)
+  have hq (j : Fin n) : 0 ≤ C.Q i j * (1 - C.survival horizon j) :=
+    mul_nonneg (C.Q_nonneg i j) (sub_nonneg.mpr (C.survival_le_one horizon j))
+  have hadd : 0 < (∑ a, C.R i a) + ∑ j, C.Q i j * (1 - C.survival horizon j) ↔
+      0 < ∑ a, C.R i a ∨ 0 < ∑ j, C.Q i j * (1 - C.survival horizon j) := by
+    have := Finset.sum_nonneg fun j (_ : j ∈ Finset.univ) => hq j
+    constructor
+    · intro h; by_cases h' : 0 < ∑ a, C.R i a
+      · exact Or.inl h'
+      · exact Or.inr (by linarith)
+    · rintro (h | h) <;> linarith
+  rw [← sub_pos, C.survival_deficit,
+    hadd,
+    Finset.sum_pos_iff_of_nonneg (fun a _ => C.R_nonneg i a),
+    Finset.sum_pos_iff_of_nonneg (fun j _ => hq j)]
+  simp only [Finset.mem_univ, true_and]
+  apply or_congr Iff.rfl
+  apply exists_congr
+  intro j
+  rw [mul_pos_iff]
+  have := C.Q_nonneg i j
+  simp only [sub_pos]
+  constructor
+  · rintro (h | h)
+    · exact h
+    · linarith [h.1]
+  · exact Or.inl
+
+-- Finite reachability sets provide the path-shortening argument without a
+-- separate graph representation. Their recurrence is the positive-edge law above.
+private def finishWithin (horizon : ℕ) : Finset (Fin n) :=
+  Finset.univ.filter fun i => C.survival horizon i < 1
+
+private lemma mem_finishWithin (horizon : ℕ) (i : Fin n) :
+    i ∈ C.finishWithin horizon ↔ C.survival horizon i < 1 := by
+  simp [finishWithin]
+
+private lemma finishWithin_mono : Monotone C.finishWithin := by
+  intro h k hle i hi
+  rw [C.mem_finishWithin] at hi ⊢
+  exact (C.survival_antitone i hle).trans_lt hi
+
+private lemma finishWithin_step {h k : ℕ}
+    (heq : C.finishWithin h = C.finishWithin k) :
+    C.finishWithin (h + 1) = C.finishWithin (k + 1) := by
+  ext i
+  simp only [C.mem_finishWithin, C.survival_succ_lt_one_iff]
+  simp_rw [← C.mem_finishWithin, heq]
+
+private lemma finishWithin_stable (horizon : ℕ) (hle : n ≤ horizon) :
+    C.finishWithin horizon = C.finishWithin n := by
+  have hc : (C.finishWithin horizon).card = (C.finishWithin n).card := by
+    apply Nat.stabilises_of_monotone (Finset.card_mono.comp C.finishWithin_mono)
+      (fun k => by simpa using Finset.card_le_univ (C.finishWithin k)) _ hle
+    intro k heq
+    have hsets := Finset.eq_of_subset_of_card_le (C.finishWithin_mono (Nat.le_succ k))
+      heq.ge
+    exact congrArg Finset.card (C.finishWithin_step hsets)
+  exact (Finset.eq_of_subset_of_card_le (C.finishWithin_mono hle) hc.le).symm
+
+/-- Finite-dimensional completeness: any positive-probability terminal route
+can be witnessed within `n` steps. The increasing reachable sets stabilize
+after at most `n` strict cardinality increases, including when `n = 0`. -/
+theorem finite_horizon_complete (i : Fin n) :
+    (∃ horizon, C.survival horizon i < 1) ↔ C.survival n i < 1 := by
+  constructor
+  · rintro ⟨horizon, hh⟩
+    by_cases hle : horizon ≤ n
+    · exact (C.survival_antitone i hle).trans_lt hh
+    · have heq := C.finishWithin_stable horizon (Nat.le_of_not_ge hle)
+      rw [← C.mem_finishWithin, ← heq, C.mem_finishWithin]
+      exact hh
+  · exact fun h => ⟨n, h⟩
+
+end Survival
+
+/-! ## Automatic full-domain absorption -/
+
+section AutomaticSolver
+
+/-- Automatically compute the maximum of zero and all `(n+1)`-step survival
+rows using the explicit `Fin n` enumeration. An empty transient domain gives zero. -/
+def autoBound : ℚ≥0 :=
+  Finset.univ.sup fun i => ⟨C.survival (n + 1) i, C.survival_nonneg (n + 1) i⟩
+
+/-- Each transient row is below the computed common survival bound. -/
+lemma survival_le_autoBound (i : Fin n) : C.survival (n + 1) i ≤ (C.autoBound : ℚ) := by
+  exact show (⟨C.survival (n + 1) i, C.survival_nonneg (n + 1) i⟩ : ℚ≥0) ≤ C.autoBound from
+    Finset.le_sup (f := fun j =>
+      (⟨C.survival (n + 1) j, C.survival_nonneg (n + 1) j⟩ : ℚ≥0)) (Finset.mem_univ i)
+
+/-- The computed bound is nonnegative and at most one, including the empty case. -/
+lemma autoBound_bounds : 0 ≤ (C.autoBound : ℚ) ∧ C.autoBound ≤ 1 := by
+  refine ⟨C.autoBound.property, Finset.sup_le fun i _ => ?_⟩
+  exact show C.survival (n + 1) i ≤ 1 from C.survival_le_one (n + 1) i
+
+/-- Exact automatic absorption test on every supplied transient state. -/
+def autoCheck : Bool := C.admissible (n + 1) C.autoBound
+
+/-- The automatic test is exactly positivity of a finite terminal route from
+every state. This theorem supplies its finite-dimensional completeness argument. -/
+theorem autoCheck_iff_reaches :
+    C.autoCheck = true ↔ ∀ i, ∃ horizon, C.survival horizon i < 1 := by
+  have hb : C.autoCheck = true ↔ C.autoBound < 1 := by
+    rw [autoCheck, C.admissible_iff]
+    have hnonneg := C.autoBound_bounds.1
+    constructor
+    · exact fun h => h.2.2.1
+    · exact fun h => ⟨Nat.zero_lt_succ n, hnonneg, h, C.survival_le_autoBound⟩
+  rw [hb, autoBound, Finset.sup_lt_iff (by norm_num : (0 : ℚ≥0) < 1)]
+  simp only [Finset.mem_univ, forall_const]
+  constructor
+  · exact fun h i => ⟨n + 1, h i⟩
+  · intro h i
+    exact (C.survival_antitone i (Nat.le_succ n)).trans_lt
+      ((C.finite_horizon_complete i).mp (h i))
+
+/-- A rejected full-domain test exhibits a state whose unfinished probability
+stays exactly one forever. It does not say that every state fails to absorb. -/
+theorem autoCheck_failure (h : C.autoCheck = false) :
+    ∃ i : Fin n, ∀ horizon, C.survival horizon i = 1 := by
+  have hn : ¬ ∀ i, ∃ horizon, C.survival horizon i < 1 := by
+    intro hr
+    have := C.autoCheck_iff_reaches.mpr hr
+    simp [h] at this
+  push Not at hn
+  obtain ⟨i, hi⟩ := hn
+  exact ⟨i, fun horizon => (C.survival_le_one horizon i).antisymm (hi horizon)⟩
+
+/-- Compute the certificate and invoke the existing exact rational solver.
+No absorption proof, block bound, candidate solution or rate is supplied. -/
+def autoSolve :
+    Except SolveError (((Fin n ⊕ Fin m) → ℚ) × ((Fin n ⊕ Fin m) → ℚ)) :=
+  C.solve (n + 1) C.autoBound
+
+/-- A failed automatic check preserves the original explicit bound error. -/
+lemma autoSolve_of_rejected (h : C.autoCheck = false) :
+    C.autoSolve = .error .absorptionBound := by
+  change C.admissible (n + 1) C.autoBound = false at h
+  simp [autoSolve, solve, h]
+
+end AutomaticSolver
+
+end Chain
+
+end FiniteMarkovChain

--- a/EconCSLib/Math/Probability/FiniteMarkovChain/Semantics.lean
+++ b/EconCSLib/Math/Probability/FiniteMarkovChain/Semantics.lean
@@ -1,0 +1,498 @@
+/-
+Copyright (c) 2026 EconCSLib contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+
+import EconCSLib.Math.Probability.FiniteMarkovChain
+import Mathlib.Analysis.Matrix.Normed
+import Mathlib.Analysis.SumOverResidueClass
+import Mathlib.Analysis.SpecificLimits.Normed
+import Mathlib.MeasureTheory.Integral.Bochner.SumMeasure
+
+/-!
+# Semantics of the exact finite absorbing-chain solver
+
+The automatically checked finite-step absorption bound gives summable powers.
+First-hit probabilities are those of `Chain.run`, including their hit times.
+The resulting countable law has total mass one and integrable reward and time.
+Cramer's actual rational output is identified with these expectations. The
+checker is proved equivalent to survival tending to zero on every supplied
+transient state. Analytic expressions occur only in statements and proofs.
+
+## Reading order
+
+Matrix-series lemmas precede one section with a shared checked-absorption
+hypothesis. It derives the first-hit probability law, both integrability
+results, and `solve_correct`. The final section proves that the automatic
+checker is equivalent to full-domain absorption and gives `autoSolve_correct`.
+-/
+
+namespace FiniteMarkovChain.Chain
+
+open Matrix MeasureTheory
+open scoped BigOperators NNReal ENNReal Matrix.Norms.Operator
+
+variable {n m : ℕ} (C : Chain n m)
+
+local notation "Qr" => C.Q.map (Rat.castHom ℝ)
+local notation "Rr" => C.R.map (Rat.castHom ℝ)
+
+/-! ## Matrix-series tools -/
+
+section MatrixSeries
+
+private lemma summable_powers_of_block {A : Matrix (Fin n) (Fin n) ℝ}
+    {k : ℕ} (hk : 0 < k) (hA : ‖A ^ k‖ < 1) : Summable (fun r : ℕ => A ^ r) := by
+  letI : NeZero k := ⟨Nat.ne_of_gt hk⟩
+  rw [Finset.sum_indicator_mod k (fun r : ℕ => A ^ r)]
+  change Summable (fun r => (∑ a : ZMod k, {n : ℕ | (n : ZMod k) = a}.indicator _) r)
+  simp only [Finset.sum_apply]
+  apply summable_sum
+  intro a _
+  rw [← ZMod.natCast_zmod_val a, summable_indicator_mod_iff_summable]
+  simpa only [pow_add, pow_mul] using
+    (summable_geometric_of_norm_lt_one hA).mul_right (A ^ a.val)
+
+private lemma summable_weighted_powers_of_block {A : Matrix (Fin n) (Fin n) ℝ}
+    {k : ℕ} (hk : 0 < k) (hA : ‖A ^ k‖ < 1) :
+    Summable (fun r : ℕ => (r + 1) • A ^ r) := by
+  letI : NeZero k := ⟨Nat.ne_of_gt hk⟩
+  rw [Finset.sum_indicator_mod k (fun r : ℕ => (r + 1) • A ^ r)]
+  change Summable (fun r => (∑ a : ZMod k, {n : ℕ | (n : ZMod k) = a}.indicator _) r)
+  simp only [Finset.sum_apply]
+  apply summable_sum
+  intro a _
+  rw [← ZMod.natCast_zmod_val a, summable_indicator_mod_iff_summable]
+  have hs := summable_geometric_of_norm_lt_one hA
+  have hw := summable_pow_mul_geometric_of_norm_lt_one 1 hA
+  simp only [pow_one] at hw
+  convert ((hw.mul_right (A ^ a.val)).const_smul k).add
+    ((hs.mul_right (A ^ a.val)).const_smul (a.val + 1)) using 1
+  funext r
+  simp only [nsmul_eq_mul, Nat.cast_add, Nat.cast_mul, Nat.cast_one,
+    pow_add, pow_mul, add_mul, mul_assoc, add_assoc, one_mul]
+
+private lemma weighted_series_identity {A : Matrix (Fin n) (Fin n) ℝ}
+    (hp : Summable (fun r : ℕ => A ^ r))
+    (hw : Summable (fun r : ℕ => (r + 1) • A ^ r)) :
+    (∑' r : ℕ, (r + 1) • A ^ r) * (1 - A) = ∑' r : ℕ, A ^ r := by
+  have hshift : HasSum (fun r : ℕ => r • A ^ r)
+      ((∑' r : ℕ, (r + 1) • A ^ r) * A) := by
+    rw [← hasSum_nat_add_iff' 1]
+    simpa [pow_succ, mul_assoc] using hw.hasSum.mul_right A
+  have hd := hw.hasSum.sub hshift
+  have heq (r : ℕ) : (r + 1) • A ^ r - r • A ^ r = A ^ r := by
+    simp [add_mul]
+  simp_rw [heq] at hd
+  simpa [mul_sub] using hd.unique hp.hasSum
+
+private lemma hasSum_mulVec {f : ℕ → Matrix (Fin n) (Fin m) ℝ}
+    {A : Matrix (Fin n) (Fin m) ℝ} (hf : HasSum f A) (b : Fin m → ℝ) :
+    HasSum (fun r => f r *ᵥ b) (A *ᵥ b) := by
+  apply Pi.hasSum.mpr
+  intro i
+  exact hasSum_sum (s := Finset.univ) fun j _ => ((Pi.hasSum.mp (Pi.hasSum.mp hf i) j).mul_right (b j))
+
+private lemma hasSum_mul {f : ℕ → Matrix (Fin n) (Fin n) ℝ}
+    {A : Matrix (Fin n) (Fin n) ℝ} (hf : HasSum f A) (B : Matrix (Fin n) (Fin m) ℝ) :
+    HasSum (fun r => f r * B) (A * B) := by
+  apply Pi.hasSum.mpr
+  intro i
+  apply Pi.hasSum.mpr
+  intro a
+  exact hasSum_sum (s := Finset.univ) fun j _ => ((Pi.hasSum.mp (Pi.hasSum.mp hf i) j).mul_right (B j a))
+
+private lemma cast_hit (r : ℕ) : (C.hit r).map (Rat.castHom ℝ) = Qr ^ r * Rr := by
+  simp only [hit, Matrix.map_mul, Matrix.map_pow]
+
+private lemma real_row_sum : (1 - Qr) *ᵥ (fun _ => (1 : ℝ)) = Rr *ᵥ (fun _ => 1) := by
+  rw [Matrix.sub_mulVec, Matrix.one_mulVec]
+  funext i
+  simp only [Pi.sub_apply, Matrix.mulVec, dotProduct, mul_one]
+  change 1 - (∑ j, (C.Q i j : ℝ)) = (∑ a, (C.R i a : ℝ))
+  have h := C.row_sum i
+  have hr : (∑ j, (C.Q i j : ℝ)) + (∑ a, (C.R i a : ℝ)) = 1 := by exact_mod_cast h
+  linarith
+
+private lemma real_hit_nonneg (r : ℕ) (i : Fin n) (a : Fin m) :
+    0 ≤ (C.hit r i a : ℝ) := by exact_mod_cast C.hit_nonneg r i a
+
+private lemma summable_joint_nonneg {f : ℕ → Fin m → ℝ} (hf : ∀ r a, 0 ≤ f r a)
+    (hs : ∀ a, Summable (fun r => f r a)) : Summable (fun p : ℕ × Fin m => f p.1 p.2) := by
+  apply (summable_prod_of_nonneg (fun p => hf p.1 p.2)).mpr
+  refine ⟨fun _ => (hasSum_fintype _).summable, ?_⟩
+  simp only [tsum_fintype]
+  exact summable_sum (s := Finset.univ) (fun a _ => hs a)
+
+end MatrixSeries
+
+/-! ## Consequences of a checked absorption bound -/
+
+section CheckedAbsorption
+
+variable {k : ℕ} {c : ℚ}
+variable (h : C.admissible k c = true)
+
+include h
+
+section Summability
+
+private lemma norm_pow_bound :
+    ‖Qr ^ k‖ < 1 := by
+  obtain ⟨_, hc, hc1, hrows⟩ := (C.admissible_iff k c).mp h
+  have hnonneg (i j : Fin n) : 0 ≤ (Qr ^ k) i j := by
+    rw [← Matrix.map_pow]
+    change 0 ≤ ((C.Q ^ k) i j : ℝ)
+    exact_mod_cast C.pow_nonneg k i j
+  have hbound : ‖Qr ^ k‖₊ ≤ (⟨(c : ℝ), by exact_mod_cast hc⟩ : ℝ≥0) := by
+    rw [Matrix.linfty_opNNNorm_def, Finset.sup_le_iff]
+    intro i _
+    apply NNReal.coe_le_coe.mp
+    simp only [NNReal.coe_sum, coe_nnnorm, Real.norm_eq_abs,
+      abs_of_nonneg (hnonneg i _)]
+    rw [← Matrix.map_pow]
+    change (∑ j, ((C.Q ^ k) i j : ℝ)) ≤ (c : ℝ)
+    exact_mod_cast hrows i
+  exact lt_of_le_of_lt (show ‖Qr ^ k‖ ≤ (c : ℝ) from hbound) (by exact_mod_cast hc1)
+
+/-- Absorption checked on a finite block makes the entire transient series summable. -/
+theorem summable_powers :
+    Summable (fun r : ℕ => Qr ^ r) :=
+  summable_powers_of_block ((C.admissible_iff k c).mp h).1 (C.norm_pow_bound h)
+
+/-- The absorption check proves nonsingularity; it is not a supplied inverse. -/
+lemma det_ne_zero :
+    (1 - C.Q).det ≠ 0 := by
+  have hs := C.summable_powers h
+  have hu : IsUnit (1 - Qr) :=
+    isUnit_iff_exists_inv.mpr ⟨∑' r : ℕ, Qr ^ r, hs.one_sub_mul_tsum_pow⟩
+  have hd := isUnit_iff_ne_zero.mp ((Matrix.isUnit_iff_isUnit_det _).mp hu)
+  have heq : ((1 - C.Q).det : ℝ) = (1 - Qr).det := by
+    rw [Rat.cast_det]
+    congr 1
+    simpa using (Rat.castHom ℝ).mapMatrix.map_sub 1 C.Q
+  intro hz
+  apply hd
+  rw [← heq, hz, Rat.cast_zero]
+
+/-- First-hit time has a finite first moment, even when absorption needs several steps. -/
+theorem summable_weighted_powers :
+    Summable (fun r : ℕ => (r + 1) • Qr ^ r) :=
+  summable_weighted_powers_of_block ((C.admissible_iff k c).mp h).1 (C.norm_pow_bound h)
+
+end Summability
+
+section FirstHitLaw
+
+private lemma hasSum_hits :
+    HasSum (fun r => (C.hit r).map (Rat.castHom ℝ))
+      ((∑' r : ℕ, Qr ^ r) * Rr) := by
+  simpa only [C.cast_hit] using hasSum_mul (C.summable_powers h).hasSum Rr
+
+/-- The eventual first-hit coefficients sum to one. No nontermination mass is discarded. -/
+theorem hasSum_firstHit (i : Fin n) :
+    HasSum (fun r => ∑ a, (C.hit r i a : ℝ)) 1 := by
+  have hs := hasSum_mulVec (C.hasSum_hits h) (fun _ => 1)
+  have heq : ((∑' r : ℕ, Qr ^ r) * Rr) *ᵥ (fun _ => (1 : ℝ)) = (fun _ => 1) := by
+    rw [← Matrix.mulVec_mulVec, ← C.real_row_sum, Matrix.mulVec_mulVec,
+      (C.summable_powers h).tsum_pow_mul_one_sub, Matrix.one_mulVec]
+  rw [heq] at hs
+  simpa only [Matrix.mulVec, dotProduct, mul_one, Matrix.map_apply] using Pi.hasSum.mp hs i
+
+private lemma summable_firstHit (i : Fin n) :
+    Summable (fun p : ℕ × Fin m => (C.hit p.1 i p.2 : ℝ)) := by
+  apply summable_joint_nonneg (fun r a => C.real_hit_nonneg r i a)
+  intro a
+  exact (Pi.hasSum.mp (Pi.hasSum.mp (C.hasSum_hits h) i) a).summable
+
+/-- The first-hit law is a probability measure derived from the executed rows. -/
+theorem firstHit_probability (i : Fin n) :
+    IsProbabilityMeasure (Measure.sum fun p : ℕ × Fin m =>
+      ENNReal.ofReal (C.hit p.1 i p.2 : ℝ) • Measure.dirac p) := by
+  constructor
+  rw [Measure.sum_apply _ MeasurableSet.univ]
+  simp only [Measure.smul_apply, Measure.dirac_apply_of_mem (Set.mem_univ _), smul_eq_mul, mul_one]
+  change (∑' p : ℕ × Fin m, ENNReal.ofReal (C.hit p.1 i p.2 : ℝ)) = 1
+  have hs := C.summable_firstHit h i
+  have ht : (∑' p : ℕ × Fin m, (C.hit p.1 i p.2 : ℝ)) = 1 := by
+    rw [hs.tsum_prod]
+    simpa only [tsum_fintype] using (C.hasSum_firstHit h i).tsum_eq
+  rw [← ENNReal.ofReal_tsum_of_nonneg
+    (fun p : ℕ × Fin m => C.real_hit_nonneg p.1 i p.2) hs, ht, ENNReal.ofReal_one]
+
+end FirstHitLaw
+
+section RewardAndTime
+
+private lemma series_solution
+    {b x : Fin n → ℚ} (hx : (1 - C.Q) *ᵥ x = b) :
+    (∑' r : ℕ, Qr ^ r) *ᵥ (fun i => (b i : ℝ)) = fun i => (x i : ℝ) := by
+  have hr : (1 - Qr) *ᵥ (fun i => (x i : ℝ)) = fun i => (b i : ℝ) := by
+    have heq : (1 - C.Q).map (Rat.castHom ℝ) = 1 - Qr := by
+      simpa using (Rat.castHom ℝ).mapMatrix.map_sub 1 C.Q
+    rw [← heq]
+    funext i
+    change ((1 - C.Q).map (Rat.castHom ℝ) *ᵥ ((Rat.castHom ℝ) ∘ x)) i = _
+    rw [← RingHom.map_mulVec, hx]
+    rfl
+  rw [← hr, Matrix.mulVec_mulVec, (C.summable_powers h).tsum_pow_mul_one_sub,
+    Matrix.one_mulVec]
+
+private lemma summable_reward_norm
+    (i : Fin n) (f : Fin m → ℝ) :
+    Summable (fun p : ℕ × Fin m => (C.hit p.1 i p.2 : ℝ) * ‖f p.2‖) := by
+  apply summable_joint_nonneg (f := fun r a => (C.hit r i a : ℝ) * ‖f a‖)
+    (fun r a => mul_nonneg (C.real_hit_nonneg r i a) (norm_nonneg (f a)))
+  intro a
+  exact (Pi.hasSum.mp (Pi.hasSum.mp (C.hasSum_hits h) i) a).summable.mul_right _
+
+/-- Any terminal-state reward is integrable under the constructed first-hit law. -/
+theorem integrable_reward
+    (i : Fin n) (f : Fin m → ℝ) :
+    Integrable (fun p : ℕ × Fin m => f p.2) (Measure.sum fun p : ℕ × Fin m =>
+      ENNReal.ofReal (C.hit p.1 i p.2 : ℝ) • Measure.dirac p) := by
+  apply integrable_sum_dirac (fun _ => ENNReal.ofReal_ne_top)
+  simpa only [ENNReal.toReal_ofReal (C.real_hit_nonneg _ _ _)] using C.summable_reward_norm h i f
+
+private lemma integral_reward_series
+    (i : Fin n) (f : Fin m → ℝ) :
+    (∫ p : ℕ × Fin m, f p.2 ∂(Measure.sum fun p : ℕ × Fin m =>
+      ENNReal.ofReal (C.hit p.1 i p.2 : ℝ) • Measure.dirac p)) =
+      (((∑' r : ℕ, Qr ^ r) * Rr) *ᵥ f) i := by
+  have hn := C.summable_reward_norm h i f
+  have hs : Summable (fun p : ℕ × Fin m => (C.hit p.1 i p.2 : ℝ) * f p.2) := by
+    apply Summable.of_norm
+    simpa only [norm_mul, Real.norm_of_nonneg (C.real_hit_nonneg _ _ _)] using hn
+  rw [integral_sum_dirac_eq_tsum (fun _ => ENNReal.ofReal_ne_top) (by
+    simpa only [ENNReal.toReal_ofReal (C.real_hit_nonneg _ _ _)] using hn)]
+  simp only [ENNReal.toReal_ofReal (C.real_hit_nonneg _ _ _), smul_eq_mul]
+  rw [hs.tsum_prod]
+  simp only [tsum_fintype]
+  exact (Pi.hasSum.mp (hasSum_mulVec (C.hasSum_hits h) f) i).tsum_eq
+
+private lemma hasSum_weighted_hits :
+    HasSum (fun r : ℕ => (r + 1) • (C.hit r).map (Rat.castHom ℝ))
+      ((∑' r : ℕ, (r + 1) • Qr ^ r) * Rr) := by
+  simpa only [C.cast_hit, Matrix.smul_mul] using
+    hasSum_mul (C.summable_weighted_powers h).hasSum Rr
+
+private lemma summable_time (i : Fin n) :
+    Summable (fun p : ℕ × Fin m => (C.hit p.1 i p.2 : ℝ) * (p.1 + 1 : ℕ)) := by
+  apply summable_joint_nonneg (f := fun r a => (C.hit r i a : ℝ) * (r + 1 : ℕ))
+    (fun r a => mul_nonneg (C.real_hit_nonneg r i a) (Nat.cast_nonneg (r + 1)))
+  intro a
+  simpa only [Matrix.smul_apply, Pi.smul_apply, nsmul_eq_mul, Matrix.map_apply, mul_comm, one_mul] using
+    (Pi.hasSum.mp (Pi.hasSum.mp (C.hasSum_weighted_hits h) i) a).summable
+
+/-- The actual hitting time, rather than just its formal Bellman residual, is integrable. -/
+theorem integrable_time (i : Fin n) :
+    Integrable (fun p : ℕ × Fin m => ((p.1 + 1 : ℕ) : ℝ)) (Measure.sum fun p : ℕ × Fin m =>
+      ENNReal.ofReal (C.hit p.1 i p.2 : ℝ) • Measure.dirac p) := by
+  apply integrable_sum_dirac (fun _ => ENNReal.ofReal_ne_top)
+  simpa only [ENNReal.toReal_ofReal (C.real_hit_nonneg _ _ _),
+    Real.norm_of_nonneg (Nat.cast_nonneg _)] using C.summable_time h i
+
+private lemma integral_time_series (i : Fin n) :
+    (∫ p : ℕ × Fin m, ((p.1 + 1 : ℕ) : ℝ) ∂(Measure.sum fun p : ℕ × Fin m =>
+      ENNReal.ofReal (C.hit p.1 i p.2 : ℝ) • Measure.dirac p)) =
+      ((∑' r : ℕ, Qr ^ r) *ᵥ (fun _ => 1)) i := by
+  have hn := C.summable_time h i
+  rw [integral_sum_dirac_eq_tsum (fun _ => ENNReal.ofReal_ne_top) (by
+    simpa only [ENNReal.toReal_ofReal (C.real_hit_nonneg _ _ _),
+      Real.norm_of_nonneg (Nat.cast_nonneg _)] using hn)]
+  simp only [ENNReal.toReal_ofReal (C.real_hit_nonneg _ _ _), smul_eq_mul]
+  rw [hn.tsum_prod]
+  simp only [tsum_fintype]
+  have hs := hasSum_mulVec (C.hasSum_weighted_hits h) (fun _ => 1)
+  have heq : ((∑' r : ℕ, (r + 1) • Qr ^ r) * Rr) *ᵥ (fun _ => (1 : ℝ)) =
+      (∑' r : ℕ, Qr ^ r) *ᵥ (fun _ => 1) := by
+    rw [← Matrix.mulVec_mulVec, ← C.real_row_sum, Matrix.mulVec_mulVec,
+      weighted_series_identity (C.summable_powers h) (C.summable_weighted_powers h)]
+  rw [heq] at hs
+  simpa only [Matrix.mulVec, dotProduct, mul_one, Matrix.smul_apply, Pi.smul_apply, nsmul_eq_mul,
+    Matrix.map_apply, mul_comm, one_mul] using (Pi.hasSum.mp hs i).tsum_eq
+
+private lemma integral_reward_of_bellman (v : Fin n → ℚ)
+    (hv : (1 - C.Q) *ᵥ v = C.R *ᵥ C.reward) (i : Fin n) :
+    (∫ p : ℕ × Fin m, (C.reward p.2 : ℝ) ∂(Measure.sum fun p : ℕ × Fin m =>
+      ENNReal.ofReal (C.hit p.1 i p.2 : ℝ) • Measure.dirac p)) = (v i : ℝ) := by
+  rw [C.integral_reward_series h i (fun a => (C.reward a : ℝ)), ← Matrix.mulVec_mulVec]
+  have hcast : Rr *ᵥ (fun a => (C.reward a : ℝ)) =
+      fun j => ((C.R *ᵥ C.reward) j : ℝ) := by
+    funext j
+    exact ((Rat.castHom ℝ).map_mulVec C.R C.reward j).symm
+  rw [hcast, C.series_solution h hv]
+
+private lemma integral_time_of_bellman (t : Fin n → ℚ)
+    (ht : (1 - C.Q) *ᵥ t = (fun _ => 1)) (i : Fin n) :
+    (∫ p : ℕ × Fin m, ((p.1 + 1 : ℕ) : ℝ) ∂(Measure.sum fun p : ℕ × Fin m =>
+      ENNReal.ofReal (C.hit p.1 i p.2 : ℝ) • Measure.dirac p)) = (t i : ℝ) := by
+  rw [C.integral_time_series h i]
+  simpa only [Rat.cast_one] using congrFun (C.series_solution h ht) i
+
+end RewardAndTime
+
+/-- The actual executable solver succeeds under its checked absorption bound.
+Its two rational vectors are the unique Bellman solutions, and their casts
+are the integrals of reward and hitting time under the constructed probability
+law. Both integrability proofs are conclusions. Terminal values are extended
+by the original reward and zero time in the returned pair. -/
+theorem solve_correct :
+    ∃ v t : Fin n → ℚ,
+      C.solve k c = .ok (Sum.elim v C.reward, Sum.elim t (fun _ => 0)) ∧
+      (1 - C.Q) *ᵥ v = C.R *ᵥ C.reward ∧ (1 - C.Q) *ᵥ t = (fun _ => 1) ∧
+      (∀ x, (1 - C.Q) *ᵥ x = C.R *ᵥ C.reward → x = v) ∧
+      (∀ x, (1 - C.Q) *ᵥ x = (fun _ => 1) → x = t) ∧
+      ∀ i : Fin n,
+        let μ := Measure.sum fun p : ℕ × Fin m =>
+          ENNReal.ofReal (C.hit p.1 i p.2 : ℝ) • Measure.dirac p
+        IsProbabilityMeasure μ ∧
+        Integrable (fun p : ℕ × Fin m => (C.reward p.2 : ℝ)) μ ∧
+        Integrable (fun p : ℕ × Fin m => ((p.1 + 1 : ℕ) : ℝ)) μ ∧
+        (∫ p : ℕ × Fin m, (C.reward p.2 : ℝ) ∂μ) = (v i : ℝ) ∧
+        (∫ p : ℕ × Fin m, ((p.1 + 1 : ℕ) : ℝ) ∂μ) = (t i : ℝ) := by
+  have hd := C.det_ne_zero h
+  obtain ⟨v, hv, ev⟩ := solveLinear_spec (1 - C.Q) (C.R *ᵥ C.reward) hd
+  obtain ⟨t, ht, et⟩ := solveLinear_spec (1 - C.Q) (fun _ => 1) hd
+  refine ⟨v, t, by simp [solve, h, hv, ht], ev, et,
+    (fun x hx => solveLinear_unique _ hd (hx.trans ev.symm)),
+    (fun x hx => solveLinear_unique _ hd (hx.trans et.symm)), ?_⟩
+  intro i
+  dsimp only
+  exact ⟨C.firstHit_probability h i,
+    C.integrable_reward h i (fun a => (C.reward a : ℝ)), C.integrable_time h i,
+    C.integral_reward_of_bellman h v ev i, C.integral_time_of_bellman h t et i⟩
+
+end CheckedAbsorption
+
+/-- Every singleton of the analytic law has the coefficient identified by
+`run_firstHit`; the law preserves the first-hit time and terminal state jointly. -/
+lemma firstHit_singleton (i : Fin n) (r : ℕ) (a : Fin m) :
+    (Measure.sum fun p : ℕ × Fin m =>
+      ENNReal.ofReal (C.hit p.1 i p.2 : ℝ) • Measure.dirac p) {(r, a)} =
+        ENNReal.ofReal (C.hit r i a : ℝ) := Measure.sum_smul_dirac_singleton
+
+/-! ## Automatic full-domain absorption -/
+
+section AutomaticAbsorption
+
+/-- Every supplied transient start has unfinished probability tending to zero.
+This property uses the original finite execution probabilities, independently
+of the automatic checker and of any proposed certificate. -/
+def AbsorbsAll : Prop :=
+  ∀ i : Fin n, Filter.Tendsto (fun horizon => (C.survival horizon i : ℝ))
+    Filter.atTop (nhds 0)
+
+/-- The exact finite automatic test is sound and complete for almost-sure
+absorption of the full supplied transient domain. Finite completeness is
+provided by `finite_horizon_complete`, not an assumption on the input chain. -/
+theorem autoCheck_iff_absorbsAll : C.autoCheck = true ↔ C.AbsorbsAll := by
+  constructor
+  · intro h i
+    have hs := (Pi.hasSum.mp
+      (hasSum_mulVec (C.summable_powers h).hasSum (fun _ => 1)) i).summable
+    have heq (r : ℕ) : (Qr ^ r *ᵥ (fun _ => 1)) i = (C.survival r i : ℝ) := by
+      rw [← Matrix.map_pow]
+      simp [survival, Matrix.mulVec, dotProduct, Matrix.map_apply]
+    simpa only [heq] using hs.tendsto_atTop_zero
+  · intro h
+    apply C.autoCheck_iff_reaches.mpr
+    intro i
+    obtain ⟨horizon, hh⟩ := ((h i).eventually_lt_const (by norm_num : (0 : ℝ) < 1)).exists
+    exact ⟨horizon, by exact_mod_cast hh⟩
+
+/-- Rejection has a particular nonabsorbing witness, even if other states
+terminate. Its original survival probability is one at every horizon. -/
+theorem autoCheck_failure_semantics (h : C.autoCheck = false) :
+    ∃ i : Fin n, (∀ horizon, C.survival horizon i = 1) ∧
+      ¬ Filter.Tendsto (fun horizon => (C.survival horizon i : ℝ))
+        Filter.atTop (nhds 0) := by
+  obtain ⟨i, hi⟩ := C.autoCheck_failure h
+  refine ⟨i, hi, ?_⟩
+  intro ht
+  obtain ⟨horizon, hh⟩ := (ht.eventually_lt_const (by norm_num : (0 : ℝ) < 1)).exists
+  simp [hi horizon] at hh
+
+/-- Full-domain absorption normalizes the original joint first-hit law.
+Its singleton coefficients are those proved by `run_firstHit` and
+`firstHit_singleton`; the time coordinate `r` denotes duration `r+1`. -/
+theorem AbsorbsAll.firstHit_probability (h : C.AbsorbsAll) (i : Fin n) :
+    IsProbabilityMeasure (Measure.sum fun p : ℕ × Fin m =>
+      ENNReal.ofReal (C.hit p.1 i p.2 : ℝ) • Measure.dirac p) :=
+  C.firstHit_probability (C.autoCheck_iff_absorbsAll.mpr h) i
+
+section SuccessfulCheck
+
+variable (h : C.autoCheck = true)
+
+include h
+
+/-- The automatic certificate makes the rational Bellman matrix nonsingular. -/
+lemma autoCheck_det_ne_zero : (1 - C.Q).det ≠ 0 :=
+  C.det_ne_zero h
+
+/-- The computed certificate guarantees actual success of `autoSolve`. Both
+returned vectors are unique Bellman solutions and equal the reward and actual
+duration integrals. Normalization and both integrability claims are conclusions;
+callers provide no block bound, inverse, candidate solution or moment hypothesis. -/
+theorem autoSolve_correct :
+    ∃ v t : Fin n → ℚ,
+      C.autoSolve = .ok (Sum.elim v C.reward, Sum.elim t (fun _ => 0)) ∧
+      (1 - C.Q) *ᵥ v = C.R *ᵥ C.reward ∧ (1 - C.Q) *ᵥ t = (fun _ => 1) ∧
+      (∀ x, (1 - C.Q) *ᵥ x = C.R *ᵥ C.reward → x = v) ∧
+      (∀ x, (1 - C.Q) *ᵥ x = (fun _ => 1) → x = t) ∧
+      ∀ i : Fin n,
+        let μ := Measure.sum fun p : ℕ × Fin m =>
+          ENNReal.ofReal (C.hit p.1 i p.2 : ℝ) • Measure.dirac p
+        IsProbabilityMeasure μ ∧
+        Integrable (fun p : ℕ × Fin m => (C.reward p.2 : ℝ)) μ ∧
+        Integrable (fun p : ℕ × Fin m => ((p.1 + 1 : ℕ) : ℝ)) μ ∧
+        (∫ p : ℕ × Fin m, (C.reward p.2 : ℝ) ∂μ) = (v i : ℝ) ∧
+        (∫ p : ℕ × Fin m, ((p.1 + 1 : ℕ) : ℝ) ∂μ) = (t i : ℝ) :=
+  C.solve_correct h
+
+/-- A pair observed in the automatic output is the pair of original first-hit
+integrals. This is a reusable consumer of the full automatic correctness theorem. -/
+theorem autoSolve_integrals (i : Fin n) (value duration : ℚ)
+    (result : C.autoSolve.map (fun vt => (vt.1 (.inl i), vt.2 (.inl i))) =
+      .ok (value, duration)) :
+    let μ := Measure.sum fun p : ℕ × Fin m =>
+      ENNReal.ofReal (C.hit p.1 i p.2 : ℝ) • Measure.dirac p
+    (∫ p : ℕ × Fin m, (C.reward p.2 : ℝ) ∂μ) = (value : ℝ) ∧
+      (∫ p : ℕ × Fin m, ((p.1 + 1 : ℕ) : ℝ) ∂μ) = (duration : ℝ) := by
+  obtain ⟨v, t, hs, _, _, _, _, hsemantic⟩ := C.autoSolve_correct h
+  have hv : v i = value ∧ t i = duration := by
+    rw [hs] at result
+    simpa only [Except.map, Sum.elim_inl, Except.ok.injEq, Prod.mk.injEq] using result
+  obtain ⟨_, _, _, he, ht⟩ := hsemantic i
+  exact ⟨he.trans (congrArg (fun q : ℚ => (q : ℝ)) hv.1),
+    ht.trans (congrArg (fun q : ℚ => (q : ℝ)) hv.2)⟩
+
+end SuccessfulCheck
+
+/-- Success of the actual automatic solver is equivalent to full-domain
+absorption; a successful check cannot fall through to the singular branch. -/
+theorem autoSolve_success_iff : (∃ vt, C.autoSolve = .ok vt) ↔ C.AbsorbsAll := by
+  constructor
+  · rintro ⟨vt, hvt⟩
+    apply C.autoCheck_iff_absorbsAll.mp
+    by_contra h
+    have hf : C.autoCheck = false := Bool.eq_false_iff.mpr h
+    rw [C.autoSolve_of_rejected hf] at hvt
+    cases hvt
+  · intro h
+    obtain ⟨v, t, hs, _⟩ := C.autoSolve_correct (C.autoCheck_iff_absorbsAll.mpr h)
+    exact ⟨_, hs⟩
+
+/-- The only possible automatic solver error is rejection of full-domain
+absorption; the retained low-level singular error is unreachable here. -/
+lemma autoSolve_ne_singular : C.autoSolve ≠ .error .singular := by
+  cases h : C.autoCheck with
+  | false => simp [C.autoSolve_of_rejected h]
+  | true =>
+    obtain ⟨v, t, hs, _⟩ := C.autoSolve_correct h
+    simp [hs]
+
+end AutomaticAbsorption
+
+end FiniteMarkovChain.Chain

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -54,6 +54,7 @@ exactly where every constraint enters.
 | Matching | `MarketDesign/Matching/` | — | Planned |
 | Mechanism design (auctions) | `MechanismDesign/` | — | Planned |
 | Foundation vocabulary | `Foundation/` | — | Planned |
+| Executable finite probability | `Math/Probability/FiniteLaw/` | [`finite-law.md`](finite-law.md) | Available |
 | Reusable mathematics | `Math/` | — | Planned |
 
 The remaining rows show where additional focused notes can be added as APIs

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -55,6 +55,7 @@ exactly where every constraint enters.
 | Mechanism design (auctions) | `MechanismDesign/` | — | Planned |
 | Foundation vocabulary | `Foundation/` | — | Planned |
 | Executable finite probability | `Math/Probability/FiniteLaw/` | [`finite-law.md`](finite-law.md) | Available |
+| Exact finite absorbing chains | `Math/Probability/FiniteMarkovChain.lean` | [`finite-markov-chain.md`](finite-markov-chain.md) | Available |
 | Reusable mathematics | `Math/` | — | Planned |
 
 The remaining rows show where additional focused notes can be added as APIs

--- a/docs/design/finite-law.md
+++ b/docs/design/finite-law.md
@@ -83,6 +83,16 @@ as proposition-valued parameters or `variable` declarations; no additional
 hypothesis abstraction is needed. Section boundaries do not add assumptions
 to the `FiniteLaw` structure.
 
+For a concrete reading example, the `MarginalComposition` section in
+`Coupling` fixes projection data, then states separate expectation and
+positive-atom hypotheses with `variable` and `include`. Two private lemmas
+discharge the corresponding obligations for both sides of `RelCoupling.bind`.
+`Conditioning` similarly separates marginal event mass, the updated product
+formula, and successful posterior equivalence before the main case split.
+In `DeferredSampling`, private lemmas for terminal, chance, and query nodes
+make the main theorem a short structural induction. These helpers organize
+proofs without adding public entry points or changing the sampled data.
+
 ## §5. Examples, verification, and scope
 
 [`tests/FiniteLawSmoke.lean`](../../tests/FiniteLawSmoke.lean) exercises exact

--- a/docs/design/finite-law.md
+++ b/docs/design/finite-law.md
@@ -1,0 +1,120 @@
+# Executable finite probability
+
+`FiniteLaw` provides exact finite probability calculations for models that
+supply nonnegative rational weights. Its algorithms and correctness theorems
+live in `Math/Probability/`, with no game-theory dependency. The stable
+`EconCSLib` import includes the aggregate
+`EconCSLib.Math.Probability.FiniteLaw`.
+
+## §1. Representation and reading order
+
+A `FiniteLaw α` contains a `List (α × ℚ≥0)` and a proof that the weights sum
+to one. Repeated outcomes and zero-weight entries are allowed. The carrier
+`α` need not be finite or decidably equal: the list supplies the finite data
+needed to execute `map`, `bind`, and rational expectation.
+
+Read the implementation in this order:
+
+| Module | Purpose and main entry points |
+|--------|-------------------------------|
+| `FiniteLaw/Core.lean` | Point laws, composition, mass, expectation, semantic equivalence, normalization |
+| `FiniteLaw/Product.lean` | `independentPair`, `finPi`, `fintypePi`, product mass and marginal theorems |
+| `FiniteLaw/Conditioning.lean` | `condition?`, `conditionOnFiber`, posterior mass and independent-table conditioning |
+| `FiniteLaw/Coupling.lean` | `RelCoupling`, its marginal witnesses, mapping and composition |
+| `FiniteLaw/DeferredSampling.lean` | `FreshQueryTree`, execution with a table or on demand, deferred-decisions theorem |
+
+These modules extract the finite-probability foundation developed for the
+EFG work. They do not depend on its strategy, history, or compiler APIs.
+
+## §2. Minimal assumptions and equality
+
+| Operation | Additional data or assumptions | Meaning |
+|-----------|--------------------------------|---------|
+| `pure`, `map`, `bind` | None on the outcome carrier | Construct and compose normalized finite laws |
+| `eventMass`, `condition?` | An executable predicate `α → Bool` | Sum or condition on selected occurrences |
+| `expectRat` | A supplied payoff `α → ℚ` | Compute an exact rational expectation |
+| `mass` | `[DecidableEq α]` | Add all occurrences equal to an outcome |
+| `conditionOnFiber` | `[DecidableEq β]`, an observation `α → β` | Condition on an observed value without equality on `α` |
+| `finPi` | A family indexed by `Fin k` | Sample independent coordinates |
+| `fintypePi` | `[Fintype I] [LinearOrder I]` | Enumerate and sample a general finite index type |
+
+Equality of structures compares atom lists. `FiniteLaw.Equivalent` instead
+compares expectations of every rational-valued function. It expresses the
+semantic equality needed for composition, reindexing, and deferred sampling
+without requiring decidable equality on the carrier. With decidable equality,
+`Equivalent.of_mass_eq` derives it from equality of point masses.
+
+The explicit order for `fintypePi` gives an executable enumeration. Its
+reindexing and marginal theorems describe the resulting law using
+`Equivalent`; they do not require identical atom-list order.
+
+## §3. Partial conditioning and fresh queries
+
+`normalize?` returns `none` for an empty or zero-total-weight list.
+`condition?` and `conditionOnFiber` consequently return `none` on a zero-mass
+event or fiber. A successful posterior whose expected payoff is zero remains
+`some 0` after mapping expectation over the result. Callers must handle an
+absent posterior explicitly.
+
+`RelCoupling R left right` carries a finite joint law of related pairs and
+proofs that its projections are equivalent to the supplied marginals.
+Mapping and binding construct new joint laws from those witnesses.
+
+`FreshQueryTree X R remaining` records the coordinates still available to
+query. A query removes its coordinate from that set, so a path cannot query
+the same coordinate twice. Chance nodes allow additional supplied finite
+randomness. `runPresampled_eq_runOnDemand` proves that sampling the available
+table in advance and sampling coordinates when queried produce equivalent
+output laws. The caller supplies the tree with its freshness evidence; this
+module does not construct that evidence for an arbitrary game or program.
+
+## §4. Source organization
+
+Each mathematical block uses `section` for a coherent group of definitions
+and results. Shared type parameters use `variable` where their scope and
+elaborated parameter order permit it. Decidability, finiteness, and substantive
+hypotheses stay close to the declarations that need them. Proof helpers use
+`lemma`; central composition, product, conditioning, and deferred-decisions
+results use `theorem`. Both are checked by the same Lean kernel.
+
+This follows Formech's readable progression from local parameters and
+hypotheses to helper lemmas and a main theorem. Lean 4 hypotheses are expressed
+as proposition-valued parameters or `variable` declarations; no additional
+hypothesis abstraction is needed. Section boundaries do not add assumptions
+to the `FiniteLaw` structure.
+
+## §5. Examples, verification, and scope
+
+[`tests/FiniteLawSmoke.lean`](../../tests/FiniteLawSmoke.lean) exercises exact
+coin probabilities, repeated atoms, a function-valued infinite carrier,
+zero-mass conditioning, finite products, couplings, and a fresh-query tree.
+It evaluates the library algorithms with `#guard` and instantiates their
+correctness theorems with ordinary Lean proofs.
+
+[`tests/FiniteLawAudit.lean`](../../tests/FiniteLawAudit.lean) discovers
+declarations by their owning module, including private and generated ones.
+It rejects noncomputable declarations and axiom dependencies beyond
+`propext`, `Quot.sound`, and `Classical.choice`. Unsafe or partial
+declarations are accepted only for Lean's recursive implementation helpers
+with a safe total definition in the same module; an opaque wrapper from
+`partial def` is rejected. Following `Lean.replay`, those
+compiler helpers are excluded from kernel replay; every safe declaration is
+replayed into an environment containing only external imports. The audit
+reports both counts. The standard logical-axiom allowance does not permit
+noncomputable runtime definitions.
+
+Run from the repository root:
+
+```bash
+lake build
+lake build EconCSLib.Examples
+lake env lean tests/FiniteLawSmoke.lean
+lake env lean tests/FiniteLawAudit.lean
+python3 scripts/check_lean_placeholders.py EconCSLib
+git diff --check
+```
+
+The executable scope is supplied finite rational data. This interface does
+not construct arbitrary real-weighted laws, general measure-theoretic
+kernels, or infinite path measures. Its lists also make no efficiency claim:
+independent products can enumerate exponentially many combinations.

--- a/docs/design/finite-markov-chain.md
+++ b/docs/design/finite-markov-chain.md
@@ -1,0 +1,126 @@
+# Exact finite absorbing Markov chains
+
+`FiniteMarkovChain.Chain n m` models a fixed finite Markov chain with rational
+transition probabilities, `n` transient states, `m` absorbing terminal states,
+and a rational terminal reward. This extracts the finite-chain algorithms
+developed alongside the EFG work into a mathematics layer that depends only
+on `FiniteLaw` and Mathlib.
+
+## Representation and reading order
+
+| Module | Purpose |
+|--------|---------|
+| `Math/Probability/FiniteMarkovChain.lean` | Transition rows, censored finite execution, absorption checks, exact Bellman solving |
+| `Math/Probability/FiniteMarkovChain/Semantics.lean` | Summability, the first-hit probability law, integrability, and correctness of the actual solver output |
+| `Examples/FiniteMarkovChain.lean` | Geometric waiting, multiple terminal outcomes, a cyclic chain, domain rejection, and ordinary theorem consumers |
+
+The stable `EconCSLib` aggregate imports the executable module. Import
+`EconCSLib.Math.Probability.FiniteMarkovChain.Semantics` explicitly for its
+analytic correctness theorems. The executable entry point does not import
+this analytic leaf or the examples.
+
+The transient and terminal blocks have type `Matrix (Fin n) (Fin n) ℚ≥0`
+and `Matrix (Fin n) (Fin m) ℚ≥0`. Each complete transient row sums to one.
+The `Fin` encodings supply executable enumeration and equality. Absorption
+is checked later, so the structure also represents chains with closed
+transient classes. No inverse, candidate solution, or moment bound is stored
+in the model.
+
+This is a fixed Markov specification. Applying it to an EFG requires a
+separate justification that the chosen states retain the relevant history
+and that transitions implement the intended policy.
+
+## Execution and time
+
+`C.run horizon i` returns a normalized `FiniteLaw` of censored outcomes:
+
+- `Sum.inl j`: execution is still transient at the supplied horizon;
+- `Sum.inr (r, a)`: the first terminal outcome is `a`, after **`r + 1`** transitions.
+
+The `r` coordinate counts preceding transient transitions. Distinct first-hit
+times remain distinct outcomes. `run_expect` specifies the complete finite
+law through transient matrix powers and first-hit coefficients;
+`run_firstHit` identifies individual hit coefficients and `run_survival`
+identifies unfinished mass. A finite horizon preserves unfinished mass even
+for an almost-surely absorbing chain.
+
+For example, a fair repeat-or-stop chain with terminal reward six has
+unfinished mass `1/4` after two steps. Its two observed hit outcomes have
+masses `1/2` and `1/4`, while `autoSolve` returns expected reward six and
+expected duration two.
+
+## Checking and solving
+
+| API | Contract |
+|-----|----------|
+| `admissible k c` | Checks `0 < k`, `0 ≤ c < 1`, and a common `k`-step survival bound `c` on every transient row |
+| `solveLinear A b` | Checks the rational determinant and computes Cramer's solution, or returns `none` for a singular matrix |
+| `solve k c` | Checks the supplied bound and solves the reward and duration Bellman systems |
+| `autoBound`, `autoCheck` | Compute the largest `(n + 1)`-step survival probability and check full-domain absorption |
+| `autoSolve` | Compute the bound and return exact reward and duration functions, including the terminal values |
+
+`finite_horizon_complete` proves that any positive-probability terminal route
+has a witness within `n` steps. `autoCheck_iff_reaches` consequently identifies
+the automatic test with existence of such a route from every supplied
+transient state. The additional step keeps the automatic block length
+positive when `n = 0`; the maximum over an empty transient domain is zero.
+
+Rejection returns `SolveError.absorptionBound`. It concerns the entire
+supplied transient domain: one start may terminate even when another is a
+closed class. `autoCheck_failure` supplies a state whose survival probability
+is one at every horizon. No successful start is silently selected or closed
+class silently removed.
+
+The low-level solver also exposes `SolveError.singular`. In the semantic
+leaf, `det_ne_zero` proves that a valid absorption bound excludes singularity,
+and `autoSolve_ne_singular` excludes that error from automatic solving.
+Terminal reward is retained verbatim, including negative values, and terminal
+duration is zero.
+
+## Correctness and source organization
+
+Read the semantic proof in four stages: summable matrix powers, the normalized
+first-hit law, reward and time integrability, then `solve_correct`.
+`autoCheck_iff_absorbsAll` proves that the exact finite check is equivalent to
+survival tending to zero for every supplied start. `autoSolve_correct` proves
+success, both Bellman equations, uniqueness, normalization, integrability,
+and equality between the actual rational output and the two real integrals.
+`autoSolve_integrals` exposes the equality for an observed output pair.
+
+Following the existing finite-law style, `section` separates mathematical
+blocks, shared parameters use `variable`, and the checked-absorption
+hypothesis is local to the results that need it. Helper results use `lemma`;
+central specifications and correctness results use `theorem`. Both forms are
+kernel-checked. The shared hypothesis does not add a field to `Chain` or
+become an argument of its executable algorithms.
+
+Analytic sums and integrals occur in propositions and proofs. They do not
+provide an algorithm for arbitrary real-weighted chains, infinite-state
+kernels, or general infinite path measures. The solver uses dense rational
+determinants and Cramer's rule; it makes no scalability claim.
+
+## Verification
+
+`tests/FiniteMarkovChainSmoke.lean` evaluates the formal library through the
+worked models with `#guard`, including multi-step and cyclic absorption,
+negative terminal rewards, singular systems, invalid bounds, domain-wide
+rejection, and an empty transient domain. The geometric example also proves its concrete
+reward and duration integrals using the Bellman equations. Normalization and theorem examples
+use ordinary Lean proofs rather than native-decision proof axioms.
+
+`tests/FiniteMarkovChainAudit.lean` checks that the executable import excludes
+the semantic leaf and examples, then discovers declarations owned by both
+library modules and the worked example, including private and generated
+ones. It rejects noncomputable declarations and nonstandard axiom dependencies,
+then replays safe declarations in a fresh environment containing only external
+imports. Compiler recursion helpers must have a safe total definition in the
+same owner module and are separately counted, as in `FiniteLawAudit`.
+
+```bash
+lake build
+lake build EconCSLib.Examples
+lake env lean tests/FiniteMarkovChainSmoke.lean
+lake env lean tests/FiniteMarkovChainAudit.lean
+python3 scripts/check_lean_placeholders.py EconCSLib
+git diff --check
+```

--- a/tests/FiniteLawAudit.lean
+++ b/tests/FiniteLawAudit.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2026 EconCSLib contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+
+import EconCSLib.Math.Probability.FiniteLaw
+import Lean
+import Lean.Replay
+
+/-!
+# Finite-law computability and proof audit
+
+Inspect all declarations owned by the finite-law import closure, including
+private and generated declarations. Reject noncomputable definitions, unsafe
+or partial declarations other than Lean's recursive implementation helpers,
+and axiom dependencies beyond Lean's standard logical axioms.
+Replay the safe declarations into an environment containing only external
+imports, so cached library proofs are checked by the kernel again.
+-/
+
+open Lean Elab Command
+
+private def isFiniteLawModule (name : Name) : Bool :=
+  (`EconCSLib.Math.Probability.FiniteLaw).isPrefixOf name
+
+elab "#audit_finite_law" : command => do
+  let env ← getEnv
+  let allowed := #[`propext, `Quot.sound, `Classical.choice]
+  let mut declarations : Std.HashMap Name ConstantInfo := {}
+  let mut recursiveHelpers := 0
+  for (name, info) in env.constants.toList do
+    if let some index := env.getModuleIdxFor? name then
+      let owner := (env.header.modules[index]!).module
+      if isFiniteLawModule owner then
+        if isNoncomputable env name then
+          throwError "Noncomputable finite-law declaration: {name}"
+        if info.isUnsafe || info.isPartial then
+          let some safeName := Compiler.isUnsafeRecName? name
+            | throwError "Unsafe or partial finite-law declaration: {name}"
+          let safeInfo ← getConstInfo safeName
+          -- A `partial def` has an opaque wrapper, not a total definition.
+          unless (safeInfo matches .defnInfo _) &&
+              !safeInfo.isUnsafe && !safeInfo.isPartial &&
+              env.getModuleIdxFor? safeName == some index do
+            throwError "Unsafe or partial finite-law declaration: {safeName}"
+          recursiveHelpers := recursiveHelpers + 1
+        for axiomName in ← collectAxioms name do
+          unless allowed.contains axiomName do
+            throwError "Forbidden finite-law axiom dependency: {name} uses {axiomName}"
+        declarations := declarations.insert name info
+  if declarations.isEmpty then
+    throwError "The finite-law audit found no declarations"
+  let imports := env.header.modules.filterMap fun entry =>
+    if isFiniteLawModule entry.module then none
+    else some ({ module := entry.module } : Import)
+  let base ← liftIO <| importModules imports {} 0
+  for (name, _) in declarations.toList do
+    if base.contains name then
+      throwError "The replay environment already contains {name}"
+  let _ ← liftIO <| base.replay declarations
+  logInfo m!"FiniteLaw: {declarations.size} declarations; zero noncomputable declarations; \
+    standard axiom dependencies; kernel replay passed for \
+    {declarations.size - recursiveHelpers} safe declarations \
+    ({recursiveHelpers} compiler recursion helpers excluded from replay)."
+
+#audit_finite_law

--- a/tests/FiniteLawSmoke.lean
+++ b/tests/FiniteLawSmoke.lean
@@ -92,6 +92,17 @@ private def diagonal := FiniteLaw.relCoupling_refl fairCoin
 example : (diagonal.joint.map fun pair => pair.1.1).Equivalent fairCoin :=
   diagonal.leftEquivalent
 
+private def coinAfterTrue (outcome : Bool) : FiniteLaw Bool :=
+  if outcome then fairCoin else FiniteLaw.pure false
+
+private def composed :=
+  diagonal.bind (leftNext := coinAfterTrue) (rightNext := coinAfterTrue) fun left right h => by
+    cases h
+    exact FiniteLaw.relCoupling_refl (coinAfterTrue left)
+
+#guard composed.joint.eventMass (fun pair => pair.1.1 && pair.1.2) = 1 / 4
+#guard composed.joint.eventMass (fun pair => pair.1.1 != pair.1.2) = 0
+
 end Couplings
 
 section DeferredSampling

--- a/tests/FiniteLawSmoke.lean
+++ b/tests/FiniteLawSmoke.lean
@@ -1,0 +1,114 @@
+/-
+Copyright (c) 2026 EconCSLib contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+
+import EconCSLib.Math.Probability.FiniteLaw
+
+/-!
+# Executable finite-law regressions
+
+The guards evaluate the main-library algorithms. The examples instantiate
+their correctness theorems; neither introduces native-decision proof axioms.
+The separate `FiniteLawAudit` replays the safe library declarations in the kernel.
+-/
+
+namespace FiniteLawSmoke
+
+private def fairCoin : FiniteLaw Bool where
+  atoms := [(false, 1 / 2), (true, 1 / 2)]
+  normalized := by norm_num
+
+section Composition
+
+#guard fairCoin.mass false = 1 / 2
+#guard fairCoin.mass true = 1 / 2
+
+private def twoCoins : FiniteLaw (Bool × Bool) :=
+  FiniteLaw.independentPair fairCoin fairCoin
+
+#guard twoCoins.mass (true, true) = 1 / 4
+#guard (fairCoin.map fun b => if b then (4 : ℚ) else 0).expectRat id = 2
+
+-- An infinite function carrier requires neither enumeration nor function equality.
+private def functions : FiniteLaw (ℕ → ℕ) :=
+  fairCoin.map fun b n => if b then n + 1 else n
+
+#guard functions.expectRat (fun f => f 3) = 7 / 2
+#guard (functions.bind fun f => FiniteLaw.pure (f 3)).mass 4 = 1 / 2
+
+-- Repeated atoms and zero-weight occurrences are part of the sparse representation.
+private def repeated : FiniteLaw Bool where
+  atoms := [(true, 1 / 4), (false, 0), (true, 3 / 4)]
+  normalized := by norm_num
+
+#guard repeated.mass true = 1
+#guard repeated.mass false = 0
+
+example : repeated.Equivalent (FiniteLaw.pure true) := by
+  intro value
+  change (1 / 4 : ℚ) * value true + (0 * value false +
+      ((3 / 4 : ℚ) * value true + 0)) = 1 * value true + 0
+  ring
+
+end Composition
+
+section Conditioning
+
+#guard (fairCoin.condition? fun outcome => outcome).map (fun law => law.mass true) = some 1
+#guard fairCoin.condition? (fun _ => false) = none
+#guard (fairCoin.conditionOnFiber id true).map (fun law => law.mass true) = some 1
+#guard fairCoin.conditionOnFiber (fun _ => false) true = none
+
+-- A possible observation with payoff zero remains a successful posterior.
+#guard (fairCoin.conditionOnFiber id false).map (fun law => law.expectRat (fun _ => 0)) =
+  some 0
+#guard (FiniteLaw.normalize? ([] : List (Bool × ℚ≥0))).isNone
+#guard (FiniteLaw.normalize? [(true, (0 : ℚ≥0))]).isNone
+
+end Conditioning
+
+section IndependentTables
+
+private def indexedCoins : FiniteLaw ((i : Fin 2) → Bool) :=
+  FiniteLaw.finPi 2 fun _ => fairCoin
+
+#guard indexedCoins.mass (fun _ => true) = 1 / 4
+#guard ((FiniteLaw.fintypePi (I := Fin 2) fun _ => fairCoin).map (fun table => table 1)).mass
+  true = 1 / 2
+
+example (laws : Fin 2 → FiniteLaw Bool) (i : Fin 2) :
+    ((FiniteLaw.fintypePi laws).map (fun table => table i)).Equivalent (laws i) :=
+  FiniteLaw.fintypePi_map_apply laws i
+
+end IndependentTables
+
+section Couplings
+
+private def diagonal := FiniteLaw.relCoupling_refl fairCoin
+
+#guard diagonal.joint.eventMass (fun pair => pair.1.1 && pair.1.2) = 1 / 2
+
+example : (diagonal.joint.map fun pair => pair.1.1).Equivalent fairCoin :=
+  diagonal.leftEquivalent
+
+end Couplings
+
+section DeferredSampling
+
+-- A chance draw decides whether to query the one available coordinate.
+private def queryTree : FiniteLaw.FreshQueryTree (fun _ : Fin 1 => Bool) Bool {0} :=
+  .chance fairCoin fun query =>
+    if query then .query ⟨0, by simp⟩ fun answer => .done answer
+    else .done false
+
+#guard (queryTree.runOnDemand (fun _ => fairCoin)).mass true = 1 / 4
+#guard (queryTree.runPresampled (fun _ => fairCoin)).mass true = 1 / 4
+
+example : (queryTree.runPresampled (fun _ => fairCoin)).Equivalent
+    (queryTree.runOnDemand (fun _ => fairCoin)) :=
+  queryTree.runPresampled_eq_runOnDemand (fun _ => fairCoin)
+
+end DeferredSampling
+
+end FiniteLawSmoke

--- a/tests/FiniteMarkovChainAudit.lean
+++ b/tests/FiniteMarkovChainAudit.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2026 EconCSLib contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+
+import EconCSLib.Examples.FiniteMarkovChain
+import Lean
+import Lean.Replay
+
+/-!
+# Finite-chain computability and proof audit
+
+Inspect declarations owned by both finite-chain library modules and the worked
+example, including private and generated declarations. Reject noncomputable definitions, unsafe
+or partial declarations other than Lean's recursive implementation helpers,
+and axiom dependencies beyond Lean's standard logical axioms.
+Replay the safe declarations into an environment containing only external
+imports, so cached library proofs are checked by the kernel again.
+-/
+
+open Lean Elab Command
+
+private def isFiniteChainModule (name : Name) : Bool :=
+  (`EconCSLib.Math.Probability.FiniteMarkovChain).isPrefixOf name ||
+  name == `EconCSLib.Examples.FiniteMarkovChain
+
+elab "#audit_finite_chain" : command => do
+  let env ← getEnv
+  let executable ← liftIO <| importModules
+    #[{ module := `EconCSLib.Math.Probability.FiniteMarkovChain }] {} 0
+  for entry in executable.header.modules do
+    if entry.module == `EconCSLib.Math.Probability.FiniteMarkovChain.Semantics ||
+        entry.module == `EconCSLib.Examples.FiniteMarkovChain then
+      throwError "Executable finite-chain import includes the semantic leaf or examples"
+  let allowed := #[`propext, `Quot.sound, `Classical.choice]
+  let mut declarations : Std.HashMap Name ConstantInfo := {}
+  let mut recursiveHelpers := 0
+  for (name, info) in env.constants.toList do
+    if let some index := env.getModuleIdxFor? name then
+      let owner := (env.header.modules[index]!).module
+      if isFiniteChainModule owner then
+        if isNoncomputable env name then
+          throwError "Noncomputable finite-chain declaration: {name}"
+        if info.isUnsafe || info.isPartial then
+          let some safeName := Compiler.isUnsafeRecName? name
+            | throwError "Unsafe or partial finite-chain declaration: {name}"
+          let safeInfo ← getConstInfo safeName
+          -- A `partial def` has an opaque wrapper, not a total definition.
+          unless (safeInfo matches .defnInfo _) &&
+              !safeInfo.isUnsafe && !safeInfo.isPartial &&
+              env.getModuleIdxFor? safeName == some index do
+            throwError "Unsafe or partial finite-chain declaration: {safeName}"
+          recursiveHelpers := recursiveHelpers + 1
+        for axiomName in ← collectAxioms name do
+          unless allowed.contains axiomName do
+            throwError "Forbidden finite-chain axiom dependency: {name} uses {axiomName}"
+        declarations := declarations.insert name info
+  if declarations.isEmpty then
+    throwError "The finite-chain audit found no declarations"
+  let imports := env.header.modules.filterMap fun entry =>
+    if isFiniteChainModule entry.module then none
+    else some ({ module := entry.module } : Import)
+  let base ← liftIO <| importModules imports {} 0
+  for (name, _) in declarations.toList do
+    if base.contains name then
+      throwError "The replay environment already contains {name}"
+  let _ ← liftIO <| base.replay declarations
+  logInfo m!"FiniteMarkovChain: {declarations.size} declarations; zero noncomputable declarations; \
+    standard axiom dependencies; kernel replay passed for \
+    {declarations.size - recursiveHelpers} safe declarations \
+    ({recursiveHelpers} compiler recursion helpers excluded from replay)."
+
+#audit_finite_chain

--- a/tests/FiniteMarkovChainSmoke.lean
+++ b/tests/FiniteMarkovChainSmoke.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2026 EconCSLib contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+
+import EconCSLib.Examples.FiniteMarkovChain
+
+/-!
+# Executable finite absorbing-chain regressions
+
+Evaluate the main-library algorithms on the worked models. Guards check exact
+rational outputs and failure branches; proof declarations use the ordinary
+kernel-checked examples and the separate declaration audit.
+-/
+
+open FiniteMarkovChain Examples.FiniteMarkovChain
+
+section Geometric
+
+#guard geometric.autoCheck
+#guard geometric.autoBound = 1 / 4
+#guard geometric.autoSolve.map (fun vt => (vt.1 (.inl 0), vt.2 (.inl 0))) = .ok (6, 2)
+#guard (geometric.run 0 0).mass (.inl 0) = 1
+#guard (geometric.run 2 0).mass (.inl 0) = 1 / 4
+#guard (geometric.run 2 0).mass (.inr (0, 0)) = 1 / 2
+#guard (geometric.run 2 0).mass (.inr (1, 0)) = 1 / 4
+#guard (geometric.run 2 0).mass (.inr (2, 0)) = 0
+#guard (geometric.solve 0 (1 / 2) matches .error .absorptionBound)
+#guard (geometric.solve 1 1 matches .error .absorptionBound)
+#guard (geometric.solve 1 (-1) matches .error .absorptionBound)
+#guard (Chain.solveLinear (0 : Matrix (Fin 1) (Fin 1) ℚ) (fun _ => 1)).isNone
+
+end Geometric
+
+section MultipleStates
+
+#guard twoStage.autoCheck
+#guard twoStage.autoSolve.map (fun vt => (vt.1 (.inl 0), vt.2 (.inl 0))) = .ok (2, 3)
+#guard twoStage.autoSolve.map (fun vt => (vt.1 (.inl 1), vt.2 (.inl 1))) = .ok (2, 2)
+#guard twoStage.autoSolve.map (fun vt => (vt.1 (.inr 0), vt.2 (.inr 0))) = .ok (-2, 0)
+#guard (twoStage.run 1 0).mass (.inl 1) = 1
+#guard (twoStage.run 2 0).mass (.inr (1, 0)) = 1 / 4
+#guard (twoStage.run 2 0).mass (.inr (1, 1)) = 1 / 4
+#guard cyclic.autoCheck
+#guard cyclic.autoSolve.map (fun vt => (vt.1 (.inl 0), vt.2 (.inl 0))) = .ok (5, 4)
+#guard cyclic.autoSolve.map (fun vt => (vt.1 (.inl 1), vt.2 (.inl 1))) = .ok (5, 3)
+#guard (cyclic.run 3 0).mass (.inr (1, 0)) = 1 / 2
+#guard (cyclic.run 3 0).mass (.inl 1) = 1 / 2
+
+end MultipleStates
+
+section DomainBoundaries
+
+-- Rejection covers the supplied domain even though one particular start succeeds.
+#guard !partiallyClosed.autoCheck
+#guard (partiallyClosed.autoSolve matches .error .absorptionBound)
+#guard (partiallyClosed.run 1 0).mass (.inr (0, 0)) = 1
+#guard partiallyClosed.survival 8 1 = 1
+#guard noTransient.autoCheck
+#guard noTransient.autoBound = 0
+#guard noTransient.autoSolve.map (fun vt => (vt.1 (.inr 0), vt.2 (.inr 0))) = .ok (-3, 0)
+
+end DomainBoundaries


### PR DESCRIPTION
Adds exact finite absorbing Markov-chain execution and solving on top of `FiniteLaw`. For example, a fair repeat-or-stop chain with terminal reward six computes expected reward six and duration two, while retaining unfinished probability `1/4` in a two-step finite run.

**Dependency:** this draft depends on #37, which is still open. The Markov-only change is commit `3726be0`; the inherited finite-law commits belong to #37. Merge #37 first, then rebase this branch onto main before marking this PR ready.

## Scope

- Two library modules: executable finite rows, censored first-hit execution, exact absorption checks and Cramer solving; a separately imported analytic leaf proving normalization, integrability, Bellman uniqueness, and equality with the actual output.
- Formech-style sections with scoped variables and checked-absorption hypotheses, helper lemmas, and main specification/correctness theorems. The 59 authored public declarations retain their interfaces; an elaborated comparison also preserves all 133 public declaration types, including generated entries, and all 53 public definition bodies. Five private proof lemmas were extracted.
- Worked examples consume the library directly. They cover geometric and cyclic absorption, multiple terminal outcomes, a partially closed domain, and an empty transient domain. The geometric example proves its concrete reward and duration integrals with ordinary Lean proofs.
- The root aggregate imports only the executable module. Examples import the semantic leaf explicitly. Add reading/scope documentation and CI checks for execution, import separation, computability, axiom dependencies, and kernel replay.

The automatic checker covers every supplied transient state. Rejection can coexist with successful absorption from another start. The finite chain is a supplied Markov specification, not a quotient of arbitrary EFG histories. Dense rational determinants and Cramer's rule make no scalability claim.

## Validation

- `lake build`: passed, 8602 jobs.
- `lake build EconCSLib.Examples`: passed, 2543 jobs.
- `lake env lean tests/FiniteMarkovChainSmoke.lean`: 31 runtime guards passed.
- `lake env lean tests/FiniteMarkovChainAudit.lean`: 194 library/example declarations, zero noncomputable declarations, standard logical axioms only; 193 safe declarations replayed in the kernel. One compiler recursion helper was separately validated and excluded from replay.
- Existing `FiniteLawSmoke` and `FiniteLawAudit`: passed.
- Placeholder and diff-whitespace checks: passed.

The new library and example modules build without warnings. Existing warnings in unrelated modules remain outside this change.
